### PR TITLE
[NAYB-75] feat: 회원은 이메일 정보를 필드로 가진다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/user/User.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/User.java
@@ -1,8 +1,10 @@
 package com.prgrms.nabmart.domain.user;
 
 import com.prgrms.nabmart.domain.BaseTimeEntity;
+import com.prgrms.nabmart.domain.user.exception.InvalidEmailException;
 import com.prgrms.nabmart.domain.user.exception.InvalidNicknameException;
 import jakarta.persistence.*;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +17,8 @@ import lombok.NoArgsConstructor;
 public class User extends BaseTimeEntity {
 
     private static final int NICKNAME_LENGTH = 200;
+    private static final Pattern EMAIL_PATTERN =
+        Pattern.compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]{1,64}@([a-zA-Z0-9.-]{1,255})$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,6 +26,9 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String nickname;
+
+    @Column
+    private String email;
 
     @Column(nullable = false)
     private String provider;
@@ -36,11 +43,14 @@ public class User extends BaseTimeEntity {
     @Builder
     public User(
         final String nickname,
+        final String email,
         final String provider,
         final String providerId,
         final UserRole userRole) {
         validateNickname(nickname);
+        validateEmail(email);
         this.nickname = nickname;
+        this.email = email;
         this.provider = provider;
         this.providerId = providerId;
         this.userRole = userRole;
@@ -49,6 +59,12 @@ public class User extends BaseTimeEntity {
     private void validateNickname(String nickname) {
         if (nickname.length() > NICKNAME_LENGTH) {
             throw new InvalidNicknameException("사용할 수 없는 닉네임입니다.");
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new InvalidEmailException("사용할 수 없는 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/exception/InvalidEmailException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/exception/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.user.exception;
+
+public class InvalidEmailException extends UserException {
+
+    public InvalidEmailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -16,17 +16,21 @@ public class UserService {
 
     @Transactional
     public RegisterUserResponse getOrRegisterUser(RegisterUserCommand registerUserCommand) {
-        User findUser = userRepository.findByProviderAndProviderId(registerUserCommand.provider(), registerUserCommand.providerId())
-                .orElseGet(() -> {
-                    User user = User.builder()
-                        .nickname(registerUserCommand.nickname())
-                        .provider(registerUserCommand.provider())
-                        .providerId(registerUserCommand.providerId())
-                        .userRole(registerUserCommand.userRole())
-                        .build();
-                    userRepository.save(user);
-                    return user;
-                });
+        User findUser = userRepository.findByProviderAndProviderId(
+                registerUserCommand.provider(),
+                registerUserCommand.providerId()
+            )
+            .orElseGet(() -> {
+                User user = User.builder()
+                    .nickname(registerUserCommand.nickname())
+                    .email(registerUserCommand.email())
+                    .provider(registerUserCommand.provider())
+                    .providerId(registerUserCommand.providerId())
+                    .userRole(registerUserCommand.userRole())
+                    .build();
+                userRepository.save(user);
+                return user;
+            });
         return RegisterUserResponse.from(findUser);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/request/RegisterUserCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/request/RegisterUserCommand.java
@@ -5,21 +5,24 @@ import lombok.Builder;
 
 @Builder
 public record RegisterUserCommand(
+    String nickname,
+    String email,
+    String provider,
+    String providerId,
+    UserRole userRole) {
+
+    public static RegisterUserCommand of(
         String nickname,
+        String email,
         String provider,
         String providerId,
         UserRole userRole) {
-
-    public static RegisterUserCommand of(
-            String nickname,
-            String provider,
-            String providerId,
-            UserRole userRole) {
         return RegisterUserCommand.builder()
-                .nickname(nickname)
-                .provider(provider)
-                .providerId(providerId)
-                .userRole(userRole)
-                .build();
+            .nickname(nickname)
+            .email(email)
+            .provider(provider)
+            .providerId(providerId)
+            .userRole(userRole)
+            .build();
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/response/RegisterUserResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/response/RegisterUserResponse.java
@@ -7,8 +7,8 @@ public record RegisterUserResponse(Long userId, UserRole userRole) {
 
     public static RegisterUserResponse from(User user) {
         return new RegisterUserResponse(
-                user.getUserId(),
-                user.getUserRole()
+            user.getUserId(),
+            user.getUserRole()
         );
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/dto/OAuthUserInfo.java
@@ -1,4 +1,4 @@
 package com.prgrms.nabmart.global.auth.oauth.dto;
 
-public record OAuthUserInfo(String oAuthUserId, String nickname) {
+public record OAuthUserInfo(String oAuthUserId, String nickname, String email) {
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -41,6 +41,7 @@ public class OAuth2AuthenticationSuccessHandler extends
 
             RegisterUserCommand registerUserCommand = RegisterUserCommand.of(
                 oAuthUserInfo.nickname(),
+                oAuthUserInfo.email(),
                 registrationId,
                 oAuthUserInfo.oAuthUserId(),
                 UserRole.ROLE_USER);

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuthProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuthProvider.java
@@ -21,13 +21,16 @@ public enum OAuthProvider {
         Map<String, String> properties = (Map<String, String>) attributes.get("properties");
         String oAuthUserId = String.valueOf(attributes.get("id"));
         String nickname = properties.get("nickname");
-        return new OAuthUserInfo(oAuthUserId, nickname);
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = String.valueOf(kakaoAccount.get("email"));
+        return new OAuthUserInfo(oAuthUserId, nickname, email);
     }),
     NAVER("naver", attributes -> {
         Map<String, String> response = (Map<String, String>) attributes.get("response");
         String oAuthUserId = response.get("id");
         String nickname = response.get("nickname");
-        return new OAuthUserInfo(oAuthUserId, nickname);
+        String email = response.get("email");
+        return new OAuthUserInfo(oAuthUserId, nickname, email);
     });
 
     private static final Map<String, OAuthProvider> PROVIDERS =

--- a/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.prgrms.nabmart.global.auth.resolver;
+
+import com.prgrms.nabmart.global.auth.LoginUser;
+import com.prgrms.nabmart.global.auth.jwt.dto.JwtAuthentication;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasParameterAnnotation = parameter.hasParameterAnnotation(LoginUser.class);
+        boolean hasLongParameterType = parameter.getParameterType().isAssignableFrom(Long.class);
+        return hasLongParameterType & hasParameterAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        JwtAuthentication jwtAuthentication = (JwtAuthentication) authentication.getPrincipal();
+        return jwtAuthentication.userId();
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/config/WebMvcConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package com.prgrms.nabmart.global.config;
+
+import com.prgrms.nabmart.global.auth.resolver.LoginUserArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserArgumentResolver());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
             client-name: naver
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            scope: nickname
+            scope: nickname, email
             redirect-uri: ${REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
@@ -19,7 +19,7 @@ spring:
             client-name: kakao
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            scope: profile_nickname
+            scope: profile_nickname, account_email
             redirect-uri: ${REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post

--- a/src/test/java/com/prgrms/nabmart/domain/user/UserTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/UserTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.prgrms.nabmart.domain.user.User.UserBuilder;
+import com.prgrms.nabmart.domain.user.exception.InvalidEmailException;
 import com.prgrms.nabmart.domain.user.exception.InvalidNicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,6 +13,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class UserTest {
+
+    private static final String NICKNAME = "nickname";
+    private static final String EMAIL = "email@example.com";
+    private static final String PROVIDER = "nayb";
+    private static final String PROVIDER_ID = "123123";
+    private static final UserRole USER_ROLE = UserRole.ROLE_USER;
 
     @Nested
     @DisplayName("User 생성 시")
@@ -22,14 +29,15 @@ class UserTest {
             "가나다", "abc", "123", "가나다123", "abc123", "가나다abc123", "가나다abc123!@#"
         })
         @DisplayName("성공: 유효한 User 닉네임")
-        void success(String validNickname) {
+        void successWhenValidNickname(String validNickname) {
             //given
             //when
             User newUser = User.builder()
                 .nickname(validNickname)
-                .provider("provider")
-                .providerId("123")
-                .userRole(UserRole.ROLE_USER)
+                .email(EMAIL)
+                .provider(PROVIDER)
+                .providerId(PROVIDER_ID)
+                .userRole(USER_ROLE)
                 .build();
 
             //then
@@ -41,14 +49,90 @@ class UserTest {
         void throwExceptionWhenInvalidNickname() {
             //given
             String invalidNickname = "a".repeat(201);
+
             //when
             //then
             UserBuilder userBuilder = User.builder()
                 .nickname(invalidNickname)
-                .provider("provider")
+                .email(EMAIL)
+                .provider(PROVIDER)
                 .providerId("123")
                 .userRole(UserRole.ROLE_USER);
             assertThatThrownBy(userBuilder::build).isInstanceOf(InvalidNicknameException.class);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "abc@example.com", "abcABC123@example.org"
+        })
+        @DisplayName("성공: 유효한 User 이메일")
+        void successWhenValidEmail(String validEmail) {
+            //given
+            //when
+            User newUser = User.builder()
+                .nickname(validEmail)
+                .email(EMAIL)
+                .provider(PROVIDER)
+                .providerId(PROVIDER_ID)
+                .userRole(USER_ROLE)
+                .build();
+
+            //then
+            assertThat(newUser.getNickname()).isEqualTo(validEmail);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "abc123.com", "abc@abc", "abc", "abc@.com", "abc@abc."
+        })
+        @DisplayName("예외: 잘못된 형식의 이메일")
+        void throwExceptionWhenInvalidEmail() {
+            //given
+            String invalidEmail = "abd123.com";
+
+            //when
+            //then
+            UserBuilder userBuilder = User.builder()
+                .nickname(NICKNAME)
+                .email(invalidEmail)
+                .provider(PROVIDER)
+                .providerId(PROVIDER_ID)
+                .userRole(USER_ROLE);
+            assertThatThrownBy(userBuilder::build).isInstanceOf(InvalidEmailException.class);
+        }
+
+        @Test
+        @DisplayName("예외: 사용자 이름이 64자를 초과하는 이메일")
+        void throwExceptionWhenInvalidEmailName() {
+            //given
+            String invalidEmailName = "a".repeat(65) + "@example.com";
+
+            //when
+            //then
+            UserBuilder userBuilder = User.builder()
+                .nickname(NICKNAME)
+                .email(invalidEmailName)
+                .provider(PROVIDER)
+                .providerId(PROVIDER_ID)
+                .userRole(USER_ROLE);
+            assertThatThrownBy(userBuilder::build).isInstanceOf(InvalidEmailException.class);
+        }
+
+        @Test
+        @DisplayName("예외: 도메인이 255자를 초과하는 이메일")
+        void throwExceptionWhenInvalidDomain() {
+            //given
+            String invalidEmailDomain = "abc@" + "a".repeat(252) + ".com";
+
+            //when
+            //then
+            UserBuilder userBuilder = User.builder()
+                .nickname(NICKNAME)
+                .email(invalidEmailDomain)
+                .provider(PROVIDER)
+                .providerId(PROVIDER_ID)
+                .userRole(USER_ROLE);
+            assertThatThrownBy(userBuilder::build).isInstanceOf(InvalidEmailException.class);
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/service/UserServiceTest.java
@@ -6,12 +6,10 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.prgrms.nabmart.domain.user.User;
-import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
 import com.prgrms.nabmart.global.fixture.UserFixture;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,24 +31,15 @@ class UserServiceTest {
     @DisplayName("getOrRegisterUser 메서드 실행 시")
     class GetOrRegisterUserTest {
 
-        RegisterUserCommand registerUserCommand;
-
-        @BeforeEach
-        void setUp() {
-            registerUserCommand = RegisterUserCommand.builder()
-                    .nickname("닉네임")
-                    .provider("kakao")
-                    .providerId("kakaoProviderId")
-                    .userRole(UserRole.ROLE_USER)
-                    .build();
-        }
+        RegisterUserCommand registerUserCommand = UserFixture.registerUserCommand();
 
         @Test
         @DisplayName("성공: User가 존재하면 User 반환")
         void getUserWhenUserExists() {
             //given
             User user = UserFixture.user();
-            given(userRepository.findByProviderAndProviderId(any(), any())).willReturn(Optional.ofNullable(user));
+            given(userRepository.findByProviderAndProviderId(any(), any())).willReturn(
+                Optional.ofNullable(user));
 
             //when
             userService.getOrRegisterUser(registerUserCommand);
@@ -63,7 +52,8 @@ class UserServiceTest {
         @DisplayName("성공: User가 존재하지 않으면 User 생성 후 저장")
         void getUserWhenUserNotFound() {
             //given
-            given(userRepository.findByProviderAndProviderId(any(), any())).willReturn(Optional.empty());
+            given(userRepository.findByProviderAndProviderId(any(), any())).willReturn(
+                Optional.empty());
 
             //when
             userService.getOrRegisterUser(registerUserCommand);

--- a/src/test/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolverTest.java
@@ -1,0 +1,70 @@
+package com.prgrms.nabmart.global.auth.resolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.prgrms.nabmart.domain.user.UserRole;
+import com.prgrms.nabmart.domain.user.service.response.RegisterUserResponse;
+import com.prgrms.nabmart.global.auth.LoginUser;
+import com.prgrms.nabmart.global.auth.jwt.TokenProvider;
+import com.prgrms.nabmart.global.fixture.AuthFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class LoginUserArgumentResolverTest {
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/resolvers")
+        public Long resolvers(@LoginUser Long userId) {
+            return userId;
+        }
+    }
+
+    MockMvc mvc;
+    TokenProvider tokenProvider;
+    RegisterUserResponse registerUserResponse;
+
+    @BeforeEach
+    void setUp() {
+        mvc = MockMvcBuilders.standaloneSetup(new TestController())
+            .setCustomArgumentResolvers(new LoginUserArgumentResolver())
+            .build();
+        tokenProvider = AuthFixture.tokenProvider();
+        registerUserResponse = new RegisterUserResponse(1L, UserRole.ROLE_USER);
+
+        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Nested
+    @DisplayName("Controller 파라미터에 LoginUser가 있다면")
+    class ResolveArgumentTest {
+
+        @Test
+        @DisplayName("성공: authentication 객체에서 userId를 추출하여 인자로 전달")
+        void success() throws Exception {
+            //given
+            String token = tokenProvider.createToken(registerUserResponse);
+
+            //when
+            ResultActions resultActions = mvc.perform(get("/resolvers")
+                .header("Authorization", token));
+
+            //then
+            resultActions.andDo(print())
+                .andExpect(jsonPath("$").isNumber());
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/global/fixture/AuthFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/AuthFixture.java
@@ -1,0 +1,28 @@
+package com.prgrms.nabmart.global.fixture;
+
+import com.prgrms.nabmart.global.auth.jwt.JavaJwtTokenProvider;
+import com.prgrms.nabmart.global.auth.jwt.TokenProvider;
+import com.prgrms.nabmart.global.auth.jwt.dto.JwtAuthentication;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+public final class AuthFixture {
+
+    private static final String ISSUER = "issuer";
+    private static final String CLIENT_SECRET = "thisIsClientSecretForTestNotARealSecretSoDontWorry";
+    private static final int EXPIRY_SECONDS = 60;
+    private static final Long USER_ID = 1L;
+    private static final String TOKEN = "token";
+
+    private AuthFixture() {
+    }
+
+    public static TokenProvider tokenProvider() {
+        return new JavaJwtTokenProvider(ISSUER, CLIENT_SECRET, EXPIRY_SECONDS);
+    }
+
+    public static Authentication usernamePasswordAuthenticationToken() {
+        JwtAuthentication authentication = new JwtAuthentication(USER_ID, TOKEN);
+        return new UsernamePasswordAuthenticationToken(authentication, null);
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
@@ -2,10 +2,12 @@ package com.prgrms.nabmart.global.fixture;
 
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.UserRole;
+import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
 
 public final class UserFixture {
 
     private static final String NICKNAME = "닉네임";
+    private static final String EMAIL = "email@example.com";
     private static final String PROVIDER = "provider";
     private static final String PROVIDER_ID = "providerId";
     private static final UserRole USER_ROLE = UserRole.ROLE_USER;
@@ -16,9 +18,20 @@ public final class UserFixture {
     public static User user() {
         return User.builder()
             .nickname(NICKNAME)
+            .email(EMAIL)
             .provider(PROVIDER)
             .providerId(PROVIDER_ID)
             .userRole(UserRole.ROLE_USER)
+            .build();
+    }
+
+    public static RegisterUserCommand registerUserCommand() {
+        return RegisterUserCommand.builder()
+            .nickname(NICKNAME)
+            .email(EMAIL)
+            .provider(PROVIDER)
+            .providerId(PROVIDER_ID)
+            .userRole(USER_ROLE)
             .build();
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 소셜 로그인 시 이메일 정보를 가지고 오도록 설정을 변경하였습니다.
- `User`에 이메일 필드를 추가하고 이에 대한 검증을 추가하였습니다.
- 컨트롤러에서 로그인한 회원 ID를 인자로 받기 위한 argument resolver를 추가하였습니다.


### 📝 작업 요약
- `User`에 `email` 필드, 검증 추가
- `LoginUserArgumentResolver` 추가


### 💡 관련 이슈
- [NAYB-4](https://naybmart.atlassian.net/browse/NAYB-4), [NAYB-75](https://naybmart.atlassian.net/browse/NAYB-75) ,[NAYB-76](https://naybmart.atlassian.net/browse/NAYB-76)


[NAYB-4]: https://naybmart.atlassian.net/browse/NAYB-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAYB-75]: https://naybmart.atlassian.net/browse/NAYB-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NAYB-76]: https://naybmart.atlassian.net/browse/NAYB-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ