### PR TITLE
[NAYB-50] feat: 구매자는 이벤트 목록을 확인할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/event/controller/EventController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/controller/EventController.java
@@ -3,10 +3,12 @@ package com.prgrms.nabmart.domain.event.controller;
 import com.prgrms.nabmart.domain.event.controller.request.RegisterEventRequest;
 import com.prgrms.nabmart.domain.event.service.EventService;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +31,10 @@ public class EventController {
         Long eventId = eventService.registerEvent(registerEventCommand);
         URI location = URI.create(BASE_URL + eventId);
         return ResponseEntity.created(location).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<FindEventsResponse> findEvents() {
+        return ResponseEntity.ok(eventService.findEvents());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/repository/EventRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.nabmart.domain.event.repository;
 
 import com.prgrms.nabmart.domain.event.domain.Event;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    
+
+    List<Event> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
@@ -3,6 +3,10 @@ package com.prgrms.nabmart.domain.event.service;
 import com.prgrms.nabmart.domain.event.domain.Event;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
 import com.prgrms.nabmart.domain.event.repository.EventRepository;
+import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
+import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse.FindEventResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,4 +24,14 @@ public class EventService {
         return registered.getEventId();
     }
 
+    @Transactional(readOnly = true)
+    public FindEventsResponse findEvents() {
+        List<Event> events = eventRepository.findAllByOrderByCreatedAtDesc();
+        return FindEventsResponse.of(events.stream()
+            .map(event -> new FindEventResponse(
+                event.getEventId(),
+                event.getTitle(),
+                event.getDescription()
+            )).collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/response/FindEventsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/response/FindEventsResponse.java
@@ -1,0 +1,14 @@
+package com.prgrms.nabmart.domain.event.service.response;
+
+import java.util.List;
+
+public record FindEventsResponse(List<FindEventResponse> events) {
+
+    public static FindEventsResponse of(final List<FindEventResponse> findEventResponses) {
+        return new FindEventsResponse(findEventResponses);
+    }
+
+    public record FindEventResponse(Long eventId, String name, String description) {
+
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/event/controller/EventControllerTest.java
@@ -3,28 +3,40 @@ package com.prgrms.nabmart.domain.event.controller;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.nabmart.domain.event.service.EventService;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
+import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse.FindEventResponse;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+@WebMvcTest(EventControllerTest.class)
 public class EventControllerTest {
 
     private MockMvc mockMvc;
 
     @Mock
     private EventService eventService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     public void setUp() {
@@ -51,6 +63,29 @@ public class EventControllerTest {
                 .andExpect(header().string("Location", "/api/v1/events/1"));
 
             verify(eventService, times(1)).registerEvent(command);
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 전체 조회하는 api 호출 시")
+    class FindEventsApi {
+
+        @Test
+        @DisplayName("성공")
+        public void success() throws Exception {
+            // Given
+            FindEventsResponse eventResponses = FindEventsResponse.of(List.of(
+                new FindEventResponse(1L, "Event 1", "Description 1"),
+                new FindEventResponse(2L, "Event 2", "Description 2")
+            ));
+            when(eventService.findEvents()).thenReturn(eventResponses);
+
+            // When & Then
+            mockMvc.perform(get("/api/v1/events"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(eventResponses)));
+
+            verify(eventService, times(1)).findEvents();
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/event/service/EventServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 import com.prgrms.nabmart.domain.event.domain.Event;
 import com.prgrms.nabmart.domain.event.repository.EventRepository;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -43,6 +45,28 @@ public class EventServiceTest {
 
             // Then
             verify(eventRepository, times(1)).save(any(Event.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("findEvents 메서드 실행 시")
+    class FindEventsTests {
+
+        @Test
+        @DisplayName("성공")
+        public void success() {
+            // Given
+            List<Event> events = Arrays.asList(
+                new Event("title 1", "description 1"),
+                new Event("title 2", "description 2")
+            );
+            when(eventRepository.findAllByOrderByCreatedAtDesc()).thenReturn(events);
+
+            // When
+            eventService.findEvents();
+
+            // Then
+            verify(eventRepository, times(1)).findAllByOrderByCreatedAtDesc();
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 이벤트 전체 조회 API

### 📝 작업 요약
- 이벤트 조회를 위한 controller, service 메서드 추가
- 응답 dto 추가 `FindEventsResponse`
- 테스트 코드

### 💡 관련 이슈
[NAYB-50](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?selectedIssue=NAYB-50)


[NAYB-50]: https://naybmart.atlassian.net/browse/NAYB-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ