### PR TITLE
[NABY-83] feat: User 엔티티 등급 필드 추가

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/user/User.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/User.java
@@ -41,7 +41,7 @@ public class User extends BaseTimeEntity {
     private UserRole userRole;
 
     @Enumerated(EnumType.STRING)
-    @Column
+    @Column(nullable = false)
     private UserGrade userGrade;
 
     @Builder

--- a/src/main/java/com/prgrms/nabmart/domain/user/User.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/User.java
@@ -40,13 +40,18 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private UserRole userRole;
 
+    @Enumerated(EnumType.STRING)
+    @Column
+    private UserGrade userGrade;
+
     @Builder
     public User(
         final String nickname,
         final String email,
         final String provider,
         final String providerId,
-        final UserRole userRole) {
+        final UserRole userRole,
+        final UserGrade userGrade) {
         validateNickname(nickname);
         validateEmail(email);
         this.nickname = nickname;
@@ -54,6 +59,7 @@ public class User extends BaseTimeEntity {
         this.provider = provider;
         this.providerId = providerId;
         this.userRole = userRole;
+        this.userGrade = userGrade;
     }
 
     private void validateNickname(String nickname) {

--- a/src/main/java/com/prgrms/nabmart/domain/user/UserGrade.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/UserGrade.java
@@ -1,0 +1,5 @@
+package com.prgrms.nabmart.domain.user;
+
+public enum UserGrade {
+    NORMAL, VIP, VVIP, RVIP
+}

--- a/src/main/java/com/prgrms/nabmart/domain/user/UserGrade.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/UserGrade.java
@@ -1,5 +1,5 @@
 package com.prgrms.nabmart.domain.user;
 
 public enum UserGrade {
-    NORMAL, VIP, VVIP, RVIP
+    NONE, NORMAL, VIP, VVIP, RVIP
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -29,6 +29,7 @@ public class UserService {
                     .provider(registerUserCommand.provider())
                     .providerId(registerUserCommand.providerId())
                     .userRole(registerUserCommand.userRole())
+                    .userGrade(registerUserCommand.userGrade())
                     .build();
                 userRepository.save(user);
                 return user;

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/request/RegisterUserCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/request/RegisterUserCommand.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.user.service.request;
 
+import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.UserRole;
 import lombok.Builder;
 
@@ -9,20 +10,23 @@ public record RegisterUserCommand(
     String email,
     String provider,
     String providerId,
-    UserRole userRole) {
+    UserRole userRole,
+    UserGrade userGrade) {
 
     public static RegisterUserCommand of(
-        String nickname,
-        String email,
-        String provider,
-        String providerId,
-        UserRole userRole) {
+        final String nickname,
+        final String email,
+        final String provider,
+        final String providerId,
+        final UserRole userRole,
+        final UserGrade userGrade) {
         return RegisterUserCommand.builder()
             .nickname(nickname)
             .email(email)
             .provider(provider)
             .providerId(providerId)
             .userRole(userRole)
+            .userGrade(userGrade)
             .build();
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/response/FindUserDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/response/FindUserDetailResponse.java
@@ -1,6 +1,7 @@
 package com.prgrms.nabmart.domain.user.service.response;
 
 import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.UserRole;
 
 public record FindUserDetailResponse(
@@ -9,7 +10,8 @@ public record FindUserDetailResponse(
     String email,
     String provider,
     String providerId,
-    UserRole userRole) {
+    UserRole userRole,
+    UserGrade userGrade) {
 
     public static FindUserDetailResponse from(final User findUser) {
         return new FindUserDetailResponse(
@@ -18,6 +20,7 @@ public record FindUserDetailResponse(
             findUser.getEmail(),
             findUser.getProvider(),
             findUser.getProviderId(),
-            findUser.getUserRole());
+            findUser.getUserRole(),
+            findUser.getUserGrade());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.global.auth.oauth.service;
 
+import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.domain.user.service.UserService;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
@@ -39,7 +40,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             oAuthUserInfo.email(),
             registrationId,
             oAuthUserInfo.oAuthUserId(),
-            UserRole.ROLE_USER);
+            UserRole.ROLE_USER,
+            UserGrade.NORMAL);
         RegisterUserResponse userResponse = userService.getOrRegisterUser(registerUserCommand);
         return new CustomOAuth2User(userResponse, attributes);
     }

--- a/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
@@ -1,6 +1,7 @@
 package com.prgrms.nabmart.global.fixture;
 
 import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
 
@@ -11,6 +12,7 @@ public final class UserFixture {
     private static final String PROVIDER = "provider";
     private static final String PROVIDER_ID = "providerId";
     private static final UserRole USER_ROLE = UserRole.ROLE_USER;
+    private static final UserGrade USER_GRADE = UserGrade.NORMAL;
 
     private UserFixture() {
     }
@@ -22,6 +24,7 @@ public final class UserFixture {
             .provider(PROVIDER)
             .providerId(PROVIDER_ID)
             .userRole(UserRole.ROLE_USER)
+            .userGrade(UserGrade.NORMAL)
             .build();
     }
 
@@ -32,6 +35,7 @@ public final class UserFixture {
             .provider(PROVIDER)
             .providerId(PROVIDER_ID)
             .userRole(USER_ROLE)
+            .userGrade(UserGrade.NORMAL)
             .build();
     }
 }

--- a/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
@@ -23,8 +23,8 @@ public final class UserFixture {
             .email(EMAIL)
             .provider(PROVIDER)
             .providerId(PROVIDER_ID)
-            .userRole(UserRole.ROLE_USER)
-            .userGrade(UserGrade.NORMAL)
+            .userRole(USER_ROLE)
+            .userGrade(USER_GRADE)
             .build();
     }
 
@@ -35,7 +35,7 @@ public final class UserFixture {
             .provider(PROVIDER)
             .providerId(PROVIDER_ID)
             .userRole(USER_ROLE)
-            .userGrade(UserGrade.NORMAL)
+            .userGrade(USER_GRADE)
             .build();
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- `User` 엔티티에 등급 필드를 추가하고 dto, 유저 생성 시점에 이를 반영하였습니다.


### 📝 작업 요약
- 회원 등급을 나타내는 `UserGrade` enum 추가
- `User` 엔티티에 `userGrade` 필드 추가
- 관련 dto에 해당 필드 추가


### 💡 관련 이슈
- [NAYB-20](https://naybmart.atlassian.net/browse/NAYB-20), [NAYB-83](https://naybmart.atlassian.net/browse/NAYB-83)


### 고려할 점
- UserGrade에 `NORMAL`, `VIP`, `VVIP`, `RVIP`는 각각 `고마운분`, `귀한분`, `더귀한분`, `천생연분`에 해당합니다. 해당 enum의 값으로 적절할지 의견을 듣고싶습니다!


[NAYB-20]: https://naybmart.atlassian.net/browse/NAYB-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAYB-83]: https://naybmart.atlassian.net/browse/NAYB-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ