### PR TITLE
[NAYB-22] feat : 구매자는 장바구니에 담긴 상품 개수를 조절할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/cart/CartItem.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/CartItem.java
@@ -73,4 +73,9 @@ public class CartItem extends BaseTimeEntity {
             throw new InvalidCartItemException("수량은 음수가 될 수 없습니다.");
         }
     }
+
+    public void changeQuantity(final Integer quantity) {
+        validateQuantity(quantity);
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
@@ -1,15 +1,19 @@
 package com.prgrms.nabmart.domain.cart.controller;
 
 import com.prgrms.nabmart.domain.cart.controller.request.RegisterCartItemRequest;
+import com.prgrms.nabmart.domain.cart.exception.CartItemException;
 import com.prgrms.nabmart.domain.cart.service.CartItemService;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
 import com.prgrms.nabmart.domain.cart.service.request.UpdateCartItemCommand;
 import com.prgrms.nabmart.global.auth.LoginUser;
+import com.prgrms.nabmart.global.util.ErrorTemplate;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/cart-items")
@@ -42,7 +47,7 @@ public class CartItemController {
 
     @DeleteMapping("/{cartItemId}")
     public ResponseEntity<Void> deleteCartItem(
-        @Valid @PathVariable Long cartItemId
+        @PathVariable Long cartItemId
     ) {
         cartItemService.deleteCartItem(cartItemId);
 
@@ -51,8 +56,8 @@ public class CartItemController {
 
     @PatchMapping("/{cartItemId}")
     public ResponseEntity<Void> updateCartItemQuantity(
-        @Valid @PathVariable Long cartItemId,
-        @Valid @RequestBody int quantity
+        @PathVariable final Long cartItemId,
+        @Valid @RequestBody final int quantity
     ) {
         UpdateCartItemCommand updateCartItemCommand = UpdateCartItemCommand.of(cartItemId,
             quantity);
@@ -60,5 +65,14 @@ public class CartItemController {
         cartItemService.updateCartItemQuantity(updateCartItemCommand);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(CartItemException.class)
+    public ResponseEntity<ErrorTemplate> handleException(
+        final CartItemException cartItemException) {
+        log.info(cartItemException.getMessage());
+
+        return ResponseEntity.badRequest()
+            .body(ErrorTemplate.of(cartItemException.getMessage()));
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
@@ -3,12 +3,14 @@ package com.prgrms.nabmart.domain.cart.controller;
 import com.prgrms.nabmart.domain.cart.controller.request.RegisterCartItemRequest;
 import com.prgrms.nabmart.domain.cart.service.CartItemService;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.request.UpdateCartItemCommand;
 import com.prgrms.nabmart.global.auth.LoginUser;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,6 +45,19 @@ public class CartItemController {
         @Valid @PathVariable Long cartItemId
     ) {
         cartItemService.deleteCartItem(cartItemId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{cartItemId}")
+    public ResponseEntity<Void> updateCartItemQuantity(
+        @Valid @PathVariable Long cartItemId,
+        @Valid @RequestBody int quantity
+    ) {
+        UpdateCartItemCommand updateCartItemCommand = UpdateCartItemCommand.of(cartItemId,
+            quantity);
+
+        cartItemService.updateCartItemQuantity(updateCartItemCommand);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -58,21 +58,22 @@ public class CartItemService {
     public void deleteCartItem(
         Long cartItemId
     ) {
-        CartItem foundCartItem = cartItemRepository.findById(cartItemId)
-            .orElseThrow(
-                () -> new NotFoundCartItemException("장바구니 상품이 존재하지 않습니다.")
-            );
+        CartItem foundCartItem = findCartItemByCartItemId(cartItemId);
 
         cartItemRepository.delete(foundCartItem);
     }
 
     @Transactional
     public void updateCartItemQuantity(UpdateCartItemCommand updateCartItemCommand) {
-        CartItem foundCartItem = cartItemRepository.findById(updateCartItemCommand.cartId())
+        CartItem foundCartItem = findCartItemByCartItemId(updateCartItemCommand.cartId());
+
+        foundCartItem.changeQuantity(updateCartItemCommand.quantity());
+    }
+
+    private CartItem findCartItemByCartItemId(Long cartItemId) {
+        return cartItemRepository.findById(cartItemId)
             .orElseThrow(
                 () -> new NotFoundCartItemException("장바구니 상품이 존재하지 않습니다.")
             );
-
-        foundCartItem.changeQuantity(updateCartItemCommand.quantity());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -6,6 +6,7 @@ import com.prgrms.nabmart.domain.cart.exception.NotFoundCartItemException;
 import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
 import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.request.UpdateCartItemCommand;
 import com.prgrms.nabmart.domain.item.domain.Item;
 import com.prgrms.nabmart.domain.item.exception.NotExistsItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
@@ -63,5 +64,15 @@ public class CartItemService {
             );
 
         cartItemRepository.delete(foundCartItem);
+    }
+
+    @Transactional
+    public void updateCartItemQuantity(UpdateCartItemCommand updateCartItemCommand) {
+        CartItem foundCartItem = cartItemRepository.findById(updateCartItemCommand.cartId())
+            .orElseThrow(
+                () -> new NotFoundCartItemException("장바구니 상품이 존재하지 않습니다.")
+            );
+
+        foundCartItem.changeQuantity(updateCartItemCommand.quantity());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/request/UpdateCartItemCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/request/UpdateCartItemCommand.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.cart.service.request;
+
+public record UpdateCartItemCommand(Long cartId, Integer quantity) {
+
+    public static UpdateCartItemCommand of(final Long cartId, final Integer quantity) {
+        return new UpdateCartItemCommand(cartId, quantity);
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -69,11 +70,12 @@ class CartItemControllerTest {
             given(cartItemService.registerCartItem(any())).willReturn(1L);
 
             // when
+            ResultActions resultActions = mockMvc.perform(post("/api/v1/cart-items")
+                .content(objectMapper.writeValueAsString(registerCartItemCommand))
+                .contentType(MediaType.APPLICATION_JSON));
 
             // then
-            mockMvc.perform(post("/api/v1/cart-items")
-                    .content(objectMapper.writeValueAsString(registerCartItemCommand))
-                    .contentType(MediaType.APPLICATION_JSON))
+            resultActions
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/v1/cart-items/1"))
                 .andDo(print())
@@ -105,7 +107,7 @@ class CartItemControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(
                 delete("/api/v1/cart-items/{cartItemId}", cartItemId)
-                    .accept(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON));
 
             // then
             resultActions.andExpect(status().isNoContent())
@@ -120,5 +122,37 @@ class CartItemControllerTest {
                 );
         }
 
+        @Nested
+        @DisplayName("장바구니 상품 수량 수정 API 실행 시")
+        class UpdateCartItemQuantityAPITest {
+
+            @Test
+            @DisplayName("성공")
+            void success() throws Exception {
+
+                // given
+                Long cartItemId = 1L;
+                int updateQuantity = 2;
+
+                // when
+                ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/cart-items/{cartItemId}", cartItemId)
+                        .content(objectMapper.writeValueAsString(updateQuantity))
+                        .contentType(MediaType.APPLICATION_JSON)
+                );
+
+                // then
+                resultActions.andExpect(status().isNoContent())
+                    .andDo(print())
+                    .andDo(
+                        document("Update cart-item quantity",
+                            preprocessRequest(prettyPrint()),
+                            pathParameters(
+                                parameterWithName("cartItemId").description("cartItemId")
+                            )
+                        )
+                    );
+            }
+        }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.cart.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -9,6 +10,7 @@ import com.prgrms.nabmart.domain.cart.CartItem;
 import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
 import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.request.UpdateCartItemCommand;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.domain.Item;
@@ -110,6 +112,31 @@ class CartItemServiceTest {
 
             // then
             then(cartItemRepository).should().delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("장바구니 상품 수량 수정 Service 실행 시")
+    class UpdateCartItemTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+
+            // given
+            Long cartItemId = 1L;
+            int updateQuantity = 2;
+            UpdateCartItemCommand updateCartItemCommand = UpdateCartItemCommand.of(cartItemId,
+                updateQuantity);
+
+            given(cartItemRepository.findById(any())).willReturn(
+                Optional.ofNullable(givenCartItem));
+
+            // when
+            cartItemService.updateCartItemQuantity(updateCartItemCommand);
+
+            // then
+            assertThat(givenCartItem.getQuantity()).isEqualTo(updateQuantity);
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 장바구니 상품 수량 변경 API 구현 
  - 상품 수량은 1씩 증감하는데 이건 프론트에서 해준다고 가정하고 상품 개수만 수정
- 장바구니 상품 수량 변경 테스트 코드 구현

### 📝 작업 요약
- 장바구니 상품 수량 변경 API 구현
- 장바구니 상품 수량 변경 테스트 코드 구현

### 💡 관련 이슈
[NAYB-22](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?label=%EC%9E%A5%EB%B0%94%EA%B5%AC%EB%8B%88%2F%EC%A2%8B%EC%95%84%EC%9A%94%2F%EB%A6%AC%EB%B7%B0&selectedIssue=NAYB-22)



[NAYB-22]: https://naybmart.atlassian.net/browse/NAYB-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ