### PR TITLE
[NAYB-44] feat: 회원은 자신의 상세 정보를 조회할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +24,13 @@ public class UserController {
 
     private final UserService userService;
     private final OAuthRestClient restClient;
+
+    @GetMapping("/users/me")
+    public ResponseEntity<FindUserDetailResponse> findUser(@LoginUser Long userId) {
+        FindUserDetailResponse findUserDetailResponse =
+            userService.findUser(FindUserCommand.from(userId));
+        return ResponseEntity.ok(findUserDetailResponse);
+    }
 
     @DeleteMapping("/users")
     public ResponseEntity<Void> deleteUser(@LoginUser Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/user/exception/DoesNotFoundUserException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/exception/DoesNotFoundUserException.java
@@ -1,8 +1,0 @@
-package com.prgrms.nabmart.domain.user.exception;
-
-public class DoesNotFoundUserException extends UserException {
-
-    public DoesNotFoundUserException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/prgrms/nabmart/domain/user/exception/NotFoundUserException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/exception/NotFoundUserException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.user.exception;
+
+public class NotFoundUserException extends UserException {
+
+    public NotFoundUserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.prgrms.nabmart.domain.user.service;
 
 import com.prgrms.nabmart.domain.user.User;
-import com.prgrms.nabmart.domain.user.exception.DoesNotFoundUserException;
+import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.service.request.FindUserCommand;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
@@ -52,6 +52,6 @@ public class UserService {
 
     private User findUserByUserId(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new DoesNotFoundUserException("존재하지 않는 유저입니다."));
+            .orElseThrow(() -> new NotFoundUserException("존재하지 않는 유저입니다."));
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
@@ -2,7 +2,16 @@ package com.prgrms.nabmart.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,16 +26,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(controllers = UserController.class)
+@AutoConfigureRestDocs
 @AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = UserController.class)
 class UserControllerTest {
 
     @Autowired
@@ -38,10 +50,58 @@ class UserControllerTest {
     @MockBean
     OAuthRestClient oAuthRestClient;
 
+    String accessToken;
+
     @BeforeEach
     void setUp() {
         Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
         SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        accessToken = AuthFixture.accessToken();
+    }
+
+    @Nested
+    @DisplayName("findUser 메서드 실행 시")
+    class FindUserTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            //given
+            FindUserDetailResponse findUserDetailResponse = UserFixture.findUserDetailResponse();
+
+            given(userService.findUser(any())).willReturn(findUserDetailResponse);
+
+            //when
+            ResultActions resultActions = mvc.perform(get("/api/v1/users/me")
+                .header("Authorization", accessToken));
+
+            //then
+            resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("Register User",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("액세스 토큰")),
+                        responseFields(
+                            fieldWithPath("userId").type(JsonFieldType.NUMBER)
+                                .description("유저 ID"),
+                            fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                .description("유저 닉네임"),
+                            fieldWithPath("email").type(JsonFieldType.STRING)
+                                .description("유저 이메일"),
+                            fieldWithPath("provider").type(JsonFieldType.STRING)
+                                .description("유저 리소스 서버"),
+                            fieldWithPath("providerId").type(JsonFieldType.STRING)
+                                .description("유저 리소스 서버 ID"),
+                            fieldWithPath("userRole").type(JsonFieldType.STRING)
+                                .description("유저 권한"),
+                            fieldWithPath("userGrade").type(JsonFieldType.STRING)
+                                .description("유저 등급")
+                        )
+                    )
+                );
+        }
     }
 
     @Nested

--- a/src/test/java/com/prgrms/nabmart/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/service/UserServiceTest.java
@@ -1,13 +1,18 @@
 package com.prgrms.nabmart.domain.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import com.prgrms.nabmart.domain.user.service.request.FindUserCommand;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
+import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import com.prgrms.nabmart.global.fixture.UserFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +65,45 @@ class UserServiceTest {
 
             //then
             then(userRepository).should(times(1)).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("findUser 메서드 실행 시")
+    class FindUserTest {
+
+        FindUserCommand findUserCommand = UserFixture.findUserCommand();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            User user = UserFixture.user();
+
+            given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+
+            //when
+            FindUserDetailResponse result = userService.findUser(findUserCommand);
+
+            //then
+            assertThat(result.nickname()).isEqualTo(user.getNickname());
+            assertThat(result.email()).isEqualTo(user.getEmail());
+            assertThat(result.provider()).isEqualTo(user.getProvider());
+            assertThat(result.providerId()).isEqualTo(user.getProviderId());
+            assertThat(result.userRole()).isEqualTo(user.getUserRole());
+            assertThat(result.userGrade()).isEqualTo(user.getUserGrade());
+        }
+
+        @Test
+        @DisplayName("예외: 존재하지 않는 User")
+        void throwExceptionWhenUserNotFound() {
+            //given
+            given(userRepository.findById(any())).willReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> userService.findUser(findUserCommand))
+                .isInstanceOf(NotFoundUserException.class);
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/UserFixture.java
@@ -3,13 +3,16 @@ package com.prgrms.nabmart.global.fixture;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.UserRole;
+import com.prgrms.nabmart.domain.user.service.request.FindUserCommand;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
+import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UserFixture {
 
+    private static final Long USER_ID = 1L;
     private static final String NICKNAME = "닉네임";
     private static final String EMAIL = "email@example.com";
     private static final String PROVIDER = "provider";
@@ -18,7 +21,6 @@ public final class UserFixture {
     private static final UserGrade USER_GRADE = UserGrade.NORMAL;
 
     public static User user() {
-
         return User.builder()
             .nickname(NICKNAME)
             .email(EMAIL)
@@ -38,5 +40,20 @@ public final class UserFixture {
             .userRole(USER_ROLE)
             .userGrade(USER_GRADE)
             .build();
+    }
+
+    public static FindUserDetailResponse findUserDetailResponse() {
+        return new FindUserDetailResponse(
+            USER_ID,
+            NICKNAME,
+            EMAIL,
+            PROVIDER,
+            PROVIDER_ID,
+            USER_ROLE,
+            USER_GRADE);
+    }
+
+    public static FindUserCommand findUserCommand() {
+        return FindUserCommand.from(USER_ID);
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 회원 상세 조회 API를 추가하였습니다.


### 📝 작업 요약
- `UserController` 회원 상세 조회 API 추가
- `UserControllerTest` 회원 상세 조회 API 테스트 작성 및 문서화 추가
- `UserServiceTest` 회원 상세 조회 메서드 테스트 작성
- `DoseNotFoundUserException` -> `NotFoundUserException`으로 이름 변경


### 💡 관련 이슈
- [NAYB-44](https://naybmart.atlassian.net/browse/NAYB-44)



[NAYB-44]: https://naybmart.atlassian.net/browse/NAYB-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ