### PR TITLE
[NAYB-89] test: 공통 테스트 컨트롤러 작성

### DIFF
--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -1,19 +1,89 @@
 package com.prgrms.nabmart.base;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.nabmart.domain.cart.service.CartItemService;
+import com.prgrms.nabmart.domain.category.service.CategoryService;
+import com.prgrms.nabmart.domain.coupon.service.CouponService;
+import com.prgrms.nabmart.domain.event.service.EventService;
+import com.prgrms.nabmart.domain.user.service.UserService;
+import com.prgrms.nabmart.global.auth.oauth.client.OAuthRestClient;
 import com.prgrms.nabmart.global.fixture.AuthFixture;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
+@WebMvcTest
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
 public abstract class BaseControllerTest {
 
-    String accessToken;
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @MockBean
+    protected UserService userService;
+
+    @MockBean
+    protected CartItemService cartItemService;
+
+    @MockBean
+    protected CategoryService categoryService;
+
+    @MockBean
+    protected CouponService couponService;
+
+    @MockBean
+    protected EventService eventService;
+
+    @MockBean
+    protected OAuthRestClient oAuthRestClient;
+
+    protected String accessToken;
 
     @BeforeEach
-    void setUp() {
+    void authenticationSetUp() {
         Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         accessToken = AuthFixture.accessToken();
+    }
+
+    @BeforeEach
+    void restDocsSetUp(
+        final WebApplicationContext context,
+        final RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+            .alwaysDo(print())
+            .alwaysDo(restDocs)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .build();
+    }
+
+    @Test
+    void contextLoads() {
+
     }
 }

--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -1,0 +1,19 @@
+package com.prgrms.nabmart.base;
+
+import com.prgrms.nabmart.global.fixture.AuthFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public abstract class BaseControllerTest {
+
+    String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        accessToken = AuthFixture.accessToken();
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/base/RestDocsConfig.java
+++ b/src/test/java/com/prgrms/nabmart/base/RestDocsConfig.java
@@ -1,0 +1,23 @@
+package com.prgrms.nabmart.base;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+            "{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint())
+        );
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
@@ -2,47 +2,21 @@ package com.prgrms.nabmart.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.prgrms.nabmart.base.BaseControllerTest;
 import com.prgrms.nabmart.domain.user.User;
-import com.prgrms.nabmart.domain.user.service.UserService;
 import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
-import com.prgrms.nabmart.global.auth.oauth.client.OAuthRestClient;
-import com.prgrms.nabmart.global.fixture.AuthFixture;
 import com.prgrms.nabmart.global.fixture.UserFixture;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(controllers = UserController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class UserControllerTest {
-
-    @Autowired
-    MockMvc mvc;
-
-    @MockBean
-    UserService userService;
-
-    @MockBean
-    OAuthRestClient oAuthRestClient;
-
-    @BeforeEach
-    void setUp() {
-        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
+class UserControllerTest extends BaseControllerTest {
 
     @Nested
     @DisplayName("deleteUser 메서드 실행 시")
@@ -50,7 +24,7 @@ class UserControllerTest {
 
         @Test
         @DisplayName("성공")
-        void success() throws Exception {
+        void DeleteUser() throws Exception {
             //given
             User user = UserFixture.user();
             FindUserDetailResponse findUserDetailResponse = FindUserDetailResponse.from(user);
@@ -58,11 +32,16 @@ class UserControllerTest {
             given(userService.findUser(any())).willReturn(findUserDetailResponse);
 
             //when
-            ResultActions resultActions = mvc.perform(delete("/api/v1/users"));
+            ResultActions resultActions = mockMvc.perform(delete("/api/v1/users")
+                .header("Authorization", accessToken));
 
             //then
-            resultActions.andDo(print())
-                .andExpect(status().isNoContent());
+            resultActions.andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName("Authorization").description("액세스 토큰")
+                    )
+                ));
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import com.prgrms.nabmart.global.fixture.UserFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -28,7 +29,7 @@ class UserControllerTest extends BaseControllerTest {
 
         @Test
         @DisplayName("성공")
-        void RegisterUser() throws Exception {
+        void FindUser() throws Exception {
             //given
             FindUserDetailResponse findUserDetailResponse = UserFixture.findUserDetailResponse();
 
@@ -36,7 +37,8 @@ class UserControllerTest extends BaseControllerTest {
 
             //when
             ResultActions resultActions = mockMvc.perform(get("/api/v1/users/me")
-                .header("Authorization", accessToken));
+                .header("Authorization", accessToken)
+                .accept(MediaType.APPLICATION_JSON));
 
             //then
             resultActions.andExpect(status().isOk())


### PR DESCRIPTION
### ⛏ 작업 사항
- 공통 테스트 컨트롤러를 작성했습니다.
- 중복되는 문서화 코드를 별도 분리하였습니다.


### 📝 작업 요약
- 중복되는 문서화 코드 분리를 위한 `RestDoscConfig` 추가
- 중복되는 인증 객체 설정을 `BaseController`에 집중


### 💡 관련 이슈
- [NAYB-89](https://naybmart.atlassian.net/browse/NAYB-89)


[NAYB-89]: https://naybmart.atlassian.net/browse/NAYB-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ