### PR TITLE
[NAYB-39] feat : 구매자는 이벤트에 포함된 상품 목록을 확인할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/event/controller/EventController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/controller/EventController.java
@@ -2,13 +2,16 @@ package com.prgrms.nabmart.domain.event.controller;
 
 import com.prgrms.nabmart.domain.event.controller.request.RegisterEventRequest;
 import com.prgrms.nabmart.domain.event.service.EventService;
+import com.prgrms.nabmart.domain.event.service.request.FindEventDetailCommand;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse;
 import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +39,13 @@ public class EventController {
     @GetMapping
     public ResponseEntity<FindEventsResponse> findEvents() {
         return ResponseEntity.ok(eventService.findEvents());
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<FindEventDetailResponse> findEventDetail(
+        @PathVariable final Long eventId
+    ) {
+        FindEventDetailCommand findEventDetailCommand = FindEventDetailCommand.from(eventId);
+        return ResponseEntity.ok(eventService.findEventDetail(findEventDetailCommand));
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/domain/Event.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/domain/Event.java
@@ -5,11 +5,15 @@ import static java.util.Objects.isNull;
 import com.prgrms.nabmart.domain.BaseTimeEntity;
 import com.prgrms.nabmart.domain.event.exception.InvalidEventDescriptionException;
 import com.prgrms.nabmart.domain.event.exception.InvalidEventTitleException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,6 +32,9 @@ public class Event extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String description;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.REMOVE)
+    private List<EventItem> eventItemList = new ArrayList<>();
 
     public Event(String title, String description) {
         validateTitle(title);

--- a/src/main/java/com/prgrms/nabmart/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/repository/EventRepository.java
@@ -2,9 +2,17 @@ package com.prgrms.nabmart.domain.event.repository;
 
 import com.prgrms.nabmart.domain.event.domain.Event;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findAllByOrderByCreatedAtDesc();
+
+    @Query("SELECT e FROM Event e "
+        + "LEFT JOIN  FETCH e.eventItemList ei "
+        + "WHERE e.eventId = :eventId")
+    Optional<Event> findByIdWithEventItems(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
@@ -1,10 +1,17 @@
 package com.prgrms.nabmart.domain.event.service;
 
 import com.prgrms.nabmart.domain.event.domain.Event;
-import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.event.exception.NotExistsEventException;
 import com.prgrms.nabmart.domain.event.repository.EventRepository;
+import com.prgrms.nabmart.domain.event.service.request.FindEventDetailCommand;
+import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse;
+import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse.EventDetailResponse;
+import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse.EventItemResponse;
 import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
 import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse.FindEventResponse;
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
+import com.prgrms.nabmart.domain.review.Review;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventService {
 
     private final EventRepository eventRepository;
+    private final ItemRepository itemRepository;
 
     @Transactional
     public Long registerEvent(RegisterEventCommand registerEventCommand) {
@@ -33,5 +41,29 @@ public class EventService {
                 event.getTitle(),
                 event.getDescription()
             )).collect(Collectors.toList()));
+    }
+
+    @Transactional(readOnly = true)
+    public FindEventDetailResponse findEventDetail(FindEventDetailCommand findEventDetailCommand) {
+        Event event = eventRepository.findByIdWithEventItems(findEventDetailCommand.eventId())
+            .orElseThrow(() -> new NotExistsEventException("존재하지 않는 이벤트입니다."));
+
+        EventDetailResponse eventDetailResponse = new EventDetailResponse(event.getEventId(),
+            event.getTitle(), event.getDescription());
+
+        List<EventItemResponse> eventItemResponses = event.getEventItemList().stream()
+            .map(eventItem -> new EventItemResponse(
+                    eventItem.getEventItemId(),
+                    eventItem.getItem().getName(),
+                    eventItem.getItem().getPrice(),
+                    eventItem.getItem().getDiscount(),
+                    eventItem.getItem().getReviewList().size(),
+                    eventItem.getItem().getLikeItemList().size(),
+                    eventItem.getItem().getReviewList().stream().mapToDouble(Review::getRate).average()
+                        .orElse(0.0)
+                )
+            ).collect(Collectors.toList());
+
+        return FindEventDetailResponse.of(eventDetailResponse, eventItemResponses);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/EventService.java
@@ -10,7 +10,6 @@ import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse.
 import com.prgrms.nabmart.domain.event.service.response.FindEventDetailResponse.EventItemResponse;
 import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse;
 import com.prgrms.nabmart.domain.event.service.response.FindEventsResponse.FindEventResponse;
-import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.review.Review;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventService {
 
     private final EventRepository eventRepository;
-    private final ItemRepository itemRepository;
 
     @Transactional
     public Long registerEvent(RegisterEventCommand registerEventCommand) {

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/request/FindEventDetailCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/request/FindEventDetailCommand.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.event.service.request;
+
+public record FindEventDetailCommand(Long eventId) {
+
+    public static FindEventDetailCommand from(final Long eventId) {
+        return new FindEventDetailCommand(eventId);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/event/service/response/FindEventDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/event/service/response/FindEventDetailResponse.java
@@ -1,0 +1,27 @@
+package com.prgrms.nabmart.domain.event.service.response;
+
+import java.util.List;
+
+public record FindEventDetailResponse(
+    EventDetailResponse event,
+    List<EventItemResponse> items
+
+) {
+
+    public static FindEventDetailResponse of(final EventDetailResponse event,
+        final List<EventItemResponse> items) {
+        return new FindEventDetailResponse(event, items);
+    }
+
+    public record EventDetailResponse(Long eventId, String eventTitle, String eventDescription
+    ) {
+
+    }
+
+    public record EventItemResponse(Long itemId, String name, int price, int discount,
+                                    int reviewCount, int like, double rate) {
+
+    }
+}
+
+

--- a/src/main/java/com/prgrms/nabmart/domain/item/domain/Item.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/domain/Item.java
@@ -2,7 +2,9 @@ package com.prgrms.nabmart.domain.item.domain;
 
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
+import com.prgrms.nabmart.domain.review.Review;
 import com.prgrms.nabmart.global.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/prgrms/nabmart/domain/item/domain/Item.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/domain/Item.java
@@ -3,6 +3,8 @@ package com.prgrms.nabmart.domain.item.domain;
 import com.prgrms.nabmart.domain.BaseTimeEntity;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
+import com.prgrms.nabmart.domain.review.Review;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +13,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,6 +58,12 @@ public class Item extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_category_id")
     private SubCategory subCategory;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.REMOVE)
+    private List<Review> reviewList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.REMOVE)
+    private List<LikeItem> likeItemList = new ArrayList<>();
 
     public Item(String name, int price, String description, int quantity, int discount,
         int maxBuyQuantity, MainCategory mainCategory, SubCategory subCategory) {

--- a/src/test/java/com/prgrms/nabmart/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/event/controller/EventControllerTest.java
@@ -3,9 +3,6 @@ package com.prgrms.nabmart.domain.event.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,22 +21,11 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@AutoConfigureRestDocs
-@AutoConfigureMockMvc(addFilters = false)
-@WebMvcTest(controllers = EventController.class)
 public class EventControllerTest extends BaseControllerTest {
-
-    @Autowired
-    MockMvc mvc;
 
     @Nested
     @DisplayName("이벤트 등록하는 api 호출 시")
@@ -56,15 +42,13 @@ public class EventControllerTest extends BaseControllerTest {
             given(eventService.registerEvent(any())).willReturn(1L);
 
             // When
-            ResultActions resultActions = mvc.perform(post("/api/v1/events")
+            ResultActions resultActions = mockMvc.perform(post("/api/v1/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
 
             // Then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("Register Event",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint())
+                .andDo(document("Register Event"
                 ));
         }
     }
@@ -85,14 +69,12 @@ public class EventControllerTest extends BaseControllerTest {
             given(eventService.findEvents()).willReturn(eventResponses);
 
             // When
-            ResultActions resultActions = mvc.perform(
+            ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/events").accept(MediaType.APPLICATION_JSON));
 
             // Then
             resultActions.andExpect(status().isOk())
                 .andDo(document("Find Events",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
                     responseFields(
                         fieldWithPath("events[].eventId").type(JsonFieldType.NUMBER)
                             .description("이벤트 ID"),
@@ -131,14 +113,12 @@ public class EventControllerTest extends BaseControllerTest {
             given(eventService.findEventDetail(any())).willReturn(eventDetailResponse);
 
             // When
-            ResultActions resultActions = mvc.perform(
+            ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/events/1").accept(MediaType.APPLICATION_JSON));
 
             // Then
             resultActions.andExpect(status().isOk())
                 .andDo(document("Find Event Detail",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
                         responseFields(
                             fieldWithPath("event.eventId").type(JsonFieldType.NUMBER)
                                 .description("이벤트 ID"),

--- a/src/test/java/com/prgrms/nabmart/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/event/service/EventServiceTest.java
@@ -7,10 +7,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.prgrms.nabmart.domain.event.domain.Event;
+import com.prgrms.nabmart.domain.event.domain.EventItem;
 import com.prgrms.nabmart.domain.event.repository.EventRepository;
+import com.prgrms.nabmart.domain.event.service.request.FindEventDetailCommand;
 import com.prgrms.nabmart.domain.event.service.request.RegisterEventCommand;
+import com.prgrms.nabmart.domain.item.domain.Item;
+import com.prgrms.nabmart.global.fixture.CategoryFixture;
+import com.prgrms.nabmart.global.fixture.EventFixture;
+import com.prgrms.nabmart.global.fixture.ItemFixture;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -67,6 +74,30 @@ public class EventServiceTest {
 
             // Then
             verify(eventRepository, times(1)).findAllByOrderByCreatedAtDesc();
+        }
+    }
+
+    @Nested
+    @DisplayName("findEventDetail 메서드 실행 시")
+    class FindEventDetailTests {
+
+        @Test
+        @DisplayName("성공")
+        public void success() {
+            // Given
+            Event event = EventFixture.event();
+            Item item = ItemFixture.item(CategoryFixture.mainCategory(),
+                CategoryFixture.subCategory(CategoryFixture.mainCategory()));
+            EventItem eventItem = new EventItem(event, item);
+            FindEventDetailCommand command = FindEventDetailCommand.from(event.getEventId());
+            when(eventRepository.findByIdWithEventItems(event.getEventId())).thenReturn(
+                Optional.of(event));
+
+            // When
+            eventService.findEventDetail(command);
+
+            // Then
+            verify(eventRepository, times(1)).findByIdWithEventItems(command.eventId());
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/global/fixture/EventFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/fixture/EventFixture.java
@@ -1,0 +1,16 @@
+package com.prgrms.nabmart.global.fixture;
+
+import com.prgrms.nabmart.domain.event.domain.Event;
+
+public final class EventFixture {
+
+    private static final String TITLE = "이벤트 이름";
+    private static final String DESCRIPTION = "이벤트 설명";
+
+    private EventFixture() {
+    }
+
+    public static Event event() {
+        return new Event(TITLE, DESCRIPTION);
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 이벤트 디테일 조회 API

### 📝 작업 요약
- 이벤트 디테일 조회를 위한 controller, service 메서드 추가
- **이벤트 디테일 조회를 위해 `Event`에 `List<EventItem>`, `Item`에 `List<Review>`, `List<Like>` 추가하였습니다!**
- 이벤트 디테일 조회를 위한 dto
- 이벤트 디테일 조회 api 테스트 코드

### 💡 관련 이슈
[NAYB-39](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?selectedIssue=NAYB-39)

[NAYB-39]: https://naybmart.atlassian.net/browse/NAYB-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ