### PR TITLE
[NAYB-92] chore: oauth2 스키마가 항상 생성되도록 하는 설정 정보 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     init:
       schema-locations: classpath:org/springframework/security/oauth2/client/oauth2-client-schema.sql
       encoding: UTF-8
+      mode: always
 
   security:
     oauth2:


### PR DESCRIPTION
### ⛏ 작업 사항
- MySQL 연결 시 oauth2_authorizaed_client 테이블이 생성되지 않는 문제를 해결하였습니다.


### 📝 작업 요약
- `application.yml`에 다음 설정을 추가하였습니다.
```yaml
sql:
  init:
    mode: always
```


### 💡 관련 이슈
- [NABY-92](https://naybmart.atlassian.net/browse/NAYB-92)

