### PR TITLE
[NAYB-86] feat : 구매자는 장바구니 목록을 조회할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/cart/Cart.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/Cart.java
@@ -31,12 +31,16 @@ public class Cart extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Cart(User user) {
+    public Cart(
+        final User user
+    ) {
         validateUser(user);
         this.user = user;
     }
 
-    public void validateUser(User user) {
+    public void validateUser(
+        final User user
+    ) {
         if (isNull(user)) {
             throw new NotExistUserException("User 가 존재하지 않습니다.");
         }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/CartItem.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/CartItem.java
@@ -46,7 +46,11 @@ public class CartItem extends BaseTimeEntity {
     private boolean isChecked;
 
     @Builder
-    public CartItem(Cart cart, Item item, int quantity) {
+    public CartItem(
+        final Cart cart,
+        final Item item,
+        final int quantity
+    ) {
         validateCart(cart);
         validateItem(item);
         validateQuantity(quantity);
@@ -56,25 +60,25 @@ public class CartItem extends BaseTimeEntity {
         this.isChecked = true;
     }
 
-    public void validateCart(Cart cart) {
+    public void validateCart(final Cart cart) {
         if (isNull(cart)) {
             throw new InvalidCartItemException("Cart 가 존재하지 않습니다.");
         }
     }
 
-    public void validateItem(Item item) {
+    public void validateItem(final Item item) {
         if (isNull(item)) {
             throw new InvalidCartItemException("Item 이 존재하지 않습니다.");
         }
     }
 
-    public void validateQuantity(int quantity) {
+    public void validateQuantity(final int quantity) {
         if (quantity < MIN_QUANTITY) {
             throw new InvalidCartItemException("수량은 음수가 될 수 없습니다.");
         }
     }
 
-    public void changeQuantity(final Integer quantity) {
+    public void changeQuantity(final int quantity) {
         validateQuantity(quantity);
         this.quantity = quantity;
     }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
@@ -3,12 +3,14 @@ package com.prgrms.nabmart.domain.cart.controller;
 import com.prgrms.nabmart.domain.cart.controller.request.RegisterCartItemRequest;
 import com.prgrms.nabmart.domain.cart.service.CartItemService;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.response.FindCartItemsResponse;
 import com.prgrms.nabmart.global.auth.LoginUser;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,5 +47,14 @@ public class CartItemController {
         cartItemService.deleteCartItem(cartItemId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{cartItemId}")
+    public ResponseEntity<FindCartItemsResponse> findCartItems(
+        @PathVariable Long cartItemId
+    ) {
+        return ResponseEntity.ok(
+            cartItemService.findCartItems(cartItemId)
+        );
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/controller/CartItemController.java
@@ -56,13 +56,12 @@ public class CartItemController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/{cartItemId}")
+    @GetMapping("/{cartItemId}/list")
     public ResponseEntity<FindCartItemsResponse> findCartItems(
         @PathVariable Long cartItemId
     ) {
-        return ResponseEntity.ok(
-            cartItemService.findCartItems(cartItemId)
-        );
+        return ResponseEntity.ok()
+            .body(cartItemService.findCartItems(cartItemId));
     }
 
     @PatchMapping("/{cartItemId}")
@@ -85,6 +84,5 @@ public class CartItemController {
 
         return ResponseEntity.badRequest()
             .body(ErrorTemplate.of(cartItemException.getMessage()));
-
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-    List<CartItem> findAllByCartItemIdAndOrderByCreatedAt(final Long cartItemId);
+    List<CartItem> findAllByCartItemIdOrderByCreatedAt(final Long cartItemId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.nabmart.domain.cart.repository;
 
 import com.prgrms.nabmart.domain.cart.CartItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
+    List<CartItem> findAllByCartItemIdAndOrderByCreatedAt(final Long cartItemId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
-    Optional<Cart> findByUser(User user);
+    Optional<Cart> findByUser(final User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -6,12 +6,15 @@ import com.prgrms.nabmart.domain.cart.exception.NotFoundCartItemException;
 import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
 import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.response.FindCartItemResponse;
+import com.prgrms.nabmart.domain.cart.service.response.FindCartItemsResponse;
 import com.prgrms.nabmart.domain.item.domain.Item;
 import com.prgrms.nabmart.domain.item.exception.NotExistsItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotExistUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +58,7 @@ public class CartItemService {
 
     @Transactional
     public void deleteCartItem(
-        Long cartItemId
+        final Long cartItemId
     ) {
         CartItem foundCartItem = cartItemRepository.findById(cartItemId)
             .orElseThrow(
@@ -63,5 +66,22 @@ public class CartItemService {
             );
 
         cartItemRepository.delete(foundCartItem);
+    }
+
+    @Transactional(readOnly = true)
+    public FindCartItemsResponse findCartItems(final Long cartItemId) {
+        List<CartItem> cartItems = cartItemRepository.findAllByCartItemIdAndOrderByCreatedAt(
+            cartItemId);
+
+        return FindCartItemsResponse.of(cartItems
+            .stream()
+            .map(
+                cartItem -> new FindCartItemResponse(
+                    cartItem.getCart().getCartId(),
+                    cartItem.getItem().getItemId(),
+                    cartItem.getQuantity()
+                )
+            )
+            .toList());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -74,7 +74,7 @@ public class CartItemService {
         return FindCartItemsResponse.of(cartItems
             .stream()
             .map(
-                cartItem -> new FindCartItemResponse(
+                cartItem -> FindCartItemResponse.of(
                     cartItem.getCart().getCartId(),
                     cartItem.getItem().getItemId(),
                     cartItem.getQuantity()

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -71,7 +71,7 @@ public class CartItemService {
         List<CartItem> cartItems = cartItemRepository.findAllByCartItemIdOrderByCreatedAt(
             cartItemId);
 
-        return FindCartItemsResponse.of(cartItems
+        return FindCartItemsResponse.from(cartItems
             .stream()
             .map(
                 cartItem -> FindCartItemResponse.of(

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/CartItemService.java
@@ -71,7 +71,7 @@ public class CartItemService {
 
     @Transactional(readOnly = true)
     public FindCartItemsResponse findCartItems(final Long cartItemId) {
-        List<CartItem> cartItems = cartItemRepository.findAllByCartItemIdAndOrderByCreatedAt(
+        List<CartItem> cartItems = cartItemRepository.findAllByCartItemIdOrderByCreatedAt(
             cartItemId);
 
         return FindCartItemsResponse.of(cartItems

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemResponse.java
@@ -1,0 +1,9 @@
+package com.prgrms.nabmart.domain.cart.service.response;
+
+public record FindCartItemResponse(
+    Long cartId,
+    Long itemId,
+    int quantity
+) {
+
+}

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemResponse.java
@@ -6,4 +6,13 @@ public record FindCartItemResponse(
     int quantity
 ) {
 
+    public static FindCartItemResponse of(
+        final Long cartId,
+        final Long itemId,
+        final int quantity
+    ) {
+        return new FindCartItemResponse(cartId,
+            itemId,
+            quantity);
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
@@ -4,7 +4,8 @@ import java.util.List;
 
 public record FindCartItemsResponse(List<FindCartItemResponse> findCartItemsResponse) {
 
-    public static FindCartItemsResponse of(final List<FindCartItemResponse> findCartItemsResponse) {
+    public static FindCartItemsResponse from(
+        final List<FindCartItemResponse> findCartItemsResponse) {
         return new FindCartItemsResponse(findCartItemsResponse);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.cart.service.response;
 
 import java.util.List;
 
-public record FindCartItemsResponse(List<FindCartItemResponse> findCartItemResponseList) {
+public record FindCartItemsResponse(List<FindCartItemResponse> findCartItemsResponse) {
 
     public static FindCartItemsResponse of(final List<FindCartItemResponse> findCartItemsResponse) {
         return new FindCartItemsResponse(findCartItemsResponse);

--- a/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/service/response/FindCartItemsResponse.java
@@ -1,0 +1,10 @@
+package com.prgrms.nabmart.domain.cart.service.response;
+
+import java.util.List;
+
+public record FindCartItemsResponse(List<FindCartItemResponse> findCartItemResponseList) {
+
+    public static FindCartItemsResponse of(final List<FindCartItemResponse> findCartItemsResponse) {
+        return new FindCartItemsResponse(findCartItemsResponse);
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
@@ -2,12 +2,9 @@ package com.prgrms.nabmart.domain.cart.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -18,48 +15,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.nabmart.domain.cart.service.CartItemService;
+import com.prgrms.nabmart.base.BaseControllerTest;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
 import com.prgrms.nabmart.domain.cart.service.response.FindCartItemResponse;
 import com.prgrms.nabmart.domain.cart.service.response.FindCartItemsResponse;
-import com.prgrms.nabmart.global.fixture.AuthFixture;
 import java.util.Collections;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@AutoConfigureRestDocs
-@WebMvcTest(CartItemController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class CartItemControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private CartItemService cartItemService;
-
-    @BeforeEach
-    void setUp() {
-        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
+class CartItemControllerTest extends BaseControllerTest {
 
     @Nested
     @DisplayName("장바구니 상품 등록 API 실행 시")
@@ -84,10 +52,7 @@ class CartItemControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/v1/cart-items/1"))
                 .andDo(print())
-                .andDo(document("Register cart-item",
-                        preprocessRequest(
-                            prettyPrint()
-                        ),
+                .andDo(restDocs.document(
                         requestFields(
                             fieldWithPath("userId").type(JsonFieldType.NUMBER).description("userId"),
                             fieldWithPath("itemId").type(JsonFieldType.NUMBER).description("itemId"),
@@ -118,8 +83,7 @@ class CartItemControllerTest {
             resultActions.andExpect(status().isNoContent())
                 .andDo(print())
                 .andDo(
-                    document("Delete cart-item",
-                        preprocessRequest(prettyPrint()),
+                    restDocs.document(
                         pathParameters(
                             parameterWithName("cartItemId").description("cartItemId")
                         )
@@ -150,8 +114,7 @@ class CartItemControllerTest {
                 resultActions.andExpect(status().isNoContent())
                     .andDo(print())
                     .andDo(
-                        document("Update cart-item quantity",
-                            preprocessRequest(prettyPrint()),
+                        restDocs.document(
                             pathParameters(
                                 parameterWithName("cartItemId").description("cartItemId")
                             )
@@ -172,7 +135,7 @@ class CartItemControllerTest {
                 Long cartId = 1L;
                 Long itemId = 1L;
                 int quantity = 5;
-                FindCartItemsResponse findCartItemsResponse = FindCartItemsResponse.of(
+                FindCartItemsResponse findCartItemsResponse = FindCartItemsResponse.from(
                     Collections.singletonList(new FindCartItemResponse(
                         cartId, itemId, quantity
                     )));
@@ -187,8 +150,7 @@ class CartItemControllerTest {
                 // then
                 resultActions.andExpect(status().isOk())
                     .andDo(print())
-                    .andDo(document("Find cart-items",
-                        preprocessRequest(prettyPrint()),
+                    .andDo(restDocs.document(
                         pathParameters(
                             parameterWithName("cartItemId").description("cartItemId")
                         ),

--- a/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
@@ -11,6 +11,7 @@ import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
 import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.cart.service.request.RegisterCartItemCommand;
 import com.prgrms.nabmart.domain.cart.service.request.UpdateCartItemCommand;
+import com.prgrms.nabmart.domain.cart.service.response.FindCartItemsResponse;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.domain.Item;
@@ -22,6 +23,8 @@ import com.prgrms.nabmart.global.fixture.CartItemFixture;
 import com.prgrms.nabmart.global.fixture.CategoryFixture;
 import com.prgrms.nabmart.global.fixture.ItemFixture;
 import com.prgrms.nabmart.global.fixture.UserFixture;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -58,6 +61,7 @@ class CartItemServiceTest {
     CartItem givenCartItem;
     int givenQuantity;
 
+
     @BeforeEach
     void setUp() {
         givenUser = UserFixture.user();
@@ -78,7 +82,7 @@ class CartItemServiceTest {
 
         @Test
         @DisplayName("성공")
-        void success() {
+        void registerCartItem() {
             // given
             given(userRepository.findById(any())).willReturn(Optional.ofNullable(givenUser));
             given(itemRepository.findById(any())).willReturn(Optional.ofNullable(givenItem));
@@ -99,7 +103,7 @@ class CartItemServiceTest {
 
         @Test
         @DisplayName("성공")
-        void success() {
+        void deleteCartItem() {
             // given
             Long cartItemId = 1L;
 
@@ -120,15 +124,21 @@ class CartItemServiceTest {
 
         @Test
         @DisplayName("성공")
-        void success() {
+        void findCartItems() {
             // given
             Long cartItemId = 1L;
+            List<CartItem> cartItems = Collections.singletonList(
+                givenCartItem
+            );
+
+            given(cartItemRepository.findAllByCartItemIdOrderByCreatedAt(cartItemId)).willReturn(
+                cartItems);
 
             // when
-            cartItemService.findCartItems(cartItemId);
+            FindCartItemsResponse findCartItemsResponse = cartItemService.findCartItems(cartItemId);
 
             // then
-            then(cartItemRepository).should().findAllByCartItemIdOrderByCreatedAt((any()));
+            assertThat(findCartItemsResponse.findCartItemsResponse()).hasSize(1);
         }
     }
 
@@ -138,7 +148,7 @@ class CartItemServiceTest {
 
         @Test
         @DisplayName("성공")
-        void success() {
+        void updateCartItem() {
             // given
             Long cartItemId = 1L;
             int updateQuantity = 2;

--- a/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
@@ -98,7 +98,6 @@ class CartItemServiceTest {
         @Test
         @DisplayName("성공")
         void success() {
-
             // given
             Long cartItemId = 1L;
 
@@ -110,6 +109,24 @@ class CartItemServiceTest {
 
             // then
             then(cartItemRepository).should().delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("장바구니 상품 목록 조회 Service 실행 시")
+    class FindCartItemsTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Long cartItemId = 1L;
+
+            // when
+            cartItemService.findCartItems(cartItemId);
+
+            // then
+            then(cartItemRepository).should().findAllByCartItemIdAndOrderByCreatedAt((any()));
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/service/CartItemServiceTest.java
@@ -128,7 +128,7 @@ class CartItemServiceTest {
             cartItemService.findCartItems(cartItemId);
 
             // then
-            then(cartItemRepository).should().findAllByCartItemIdAndOrderByCreatedAt((any()));
+            then(cartItemRepository).should().findAllByCartItemIdOrderByCreatedAt((any()));
         }
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 장바구니 상품 목록 조회 API 구현
  - 장바구니 상품은 수량도 적고 주문 시 한번에 계산하기 때문에 page 대신 List로 반환했습니다.
- 장바구니 상품 목록 조회 테스트 코드 구현

### 📝 작업 요약
- 장바구니 상품 목록 조회 API 구현
- 장바구니 상품 목록 조회 테스트 코드 구현

### 💡 관련 이슈
[NAYB-86](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?label=%EC%9E%A5%EB%B0%94%EA%B5%AC%EB%8B%88%2F%EC%A2%8B%EC%95%84%EC%9A%94%2F%EB%A6%AC%EB%B7%B0&selectedIssue=NAYB-86)



[NAYB-86]: https://naybmart.atlassian.net/browse/NAYB-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ