### PR TITLE
[NAYB-98] fix: 로컬 빌드시 mysql 스키마 생성시 발생하는 오류 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
 
   sql:
     init:
-      schema-locations: classpath:org/springframework/security/oauth2/client/oauth2-client-schema.sql
+      schema-locations: classpath:sql/oauth2-client-schema.sql
       encoding: UTF-8
       mode: always
 

--- a/src/main/resources/sql/oauth2-client-schema.sql
+++ b/src/main/resources/sql/oauth2-client-schema.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS oauth2_authorized_client;
+CREATE TABLE oauth2_authorized_client
+(
+    client_registration_id  varchar(100)                            NOT NULL,
+    principal_name          varchar(200)                            NOT NULL,
+    access_token_type       varchar(100)                            NOT NULL,
+    access_token_value      blob                                    NOT NULL,
+    access_token_issued_at  timestamp                               NOT NULL,
+    access_token_expires_at timestamp                               NOT NULL,
+    access_token_scopes     varchar(1000) DEFAULT NULL,
+    refresh_token_value     blob          DEFAULT NULL,
+    refresh_token_issued_at timestamp     DEFAULT NULL,
+    created_at              timestamp     DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    PRIMARY KEY (client_registration_id, principal_name)
+);


### PR DESCRIPTION
### ⛏ 작업 사항
- 로컬 빌드에 mysql을 사용할 시 빌드 실패하는 오류를 수정했습니다.
- `oauth2_authorized_client` 테이블 생성이 `ddl-auto` 옵션에 영향을 받지 않도록 해당 스키마의 ddl과 application.yml을 수정하였습니다.
- 해당 스키마와 관련된 설정은 로컬 빌드 용입니다. 실제 환경에서는 사용되지 않습니다.


### 📝 작업 요약
- 커스텀 `oauth2_authorized_client.sql` 추가
- `application.yml` `schema-locations` 변경


### 💡 관련 이슈
- [NAYB-98](https://naybmart.atlassian.net/browse/NAYB-98)



[NAYB-98]: https://naybmart.atlassian.net/browse/NAYB-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ