### PR TITLE
[NAYB-100] feat: 구매자는 찜한 상품을 취소할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/item/LikeItem.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/LikeItem.java
@@ -36,7 +36,7 @@ public class LikeItem {
         this.item = item;
     }
 
-    public boolean isSameUser(Long userId) {
+    public boolean isSameUser(final Long userId) {
         return user.isSameUserId(userId);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/LikeItem.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/LikeItem.java
@@ -35,4 +35,8 @@ public class LikeItem {
         this.user = user;
         this.item = item;
     }
+
+    public boolean isSameUser(Long userId) {
+        return user.isSameUserId(userId);
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/LikeItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/LikeItemController.java
@@ -2,12 +2,15 @@ package com.prgrms.nabmart.domain.item.controller;
 
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
 import com.prgrms.nabmart.domain.item.service.LikeItemService;
+import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
 import com.prgrms.nabmart.global.auth.LoginUser;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,11 +28,21 @@ public class LikeItemController {
     @PostMapping
     public ResponseEntity<Void> registerLikeItem(
         @RequestBody @Valid RegisterLikeItemRequest registerLikeItemRequest,
-        @LoginUser Long userId) {
+        @LoginUser final Long userId) {
         RegisterLikeItemCommand registerLikeItemCommand
             = RegisterLikeItemCommand.of(userId, registerLikeItemRequest.itemId());
         Long likeItemId = likeItemService.registerLikeItem(registerLikeItemCommand);
         URI location = URI.create(BASE_URI + likeItemId);
         return ResponseEntity.created(location).build();
+    }
+
+    @DeleteMapping("/{likeItemId}")
+    public ResponseEntity<Void> deleteLikeItem(
+        @PathVariable final Long likeItemId,
+        @LoginUser final Long userId
+    ) {
+        DeleteLikeItemCommand deleteLikeItemCommand = DeleteLikeItemCommand.of(userId, likeItemId);
+        likeItemService.deleteLikeItem(deleteLikeItemCommand);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/exception/NotFoundLikeItemException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/exception/NotFoundLikeItemException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.item.exception;
+
+public class NotFoundLikeItemException extends ItemException {
+
+    public NotFoundLikeItemException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/item/exception/NotFoundLikeItemException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/exception/NotFoundLikeItemException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.item.exception;
 
 public class NotFoundLikeItemException extends ItemException {
 
-    public NotFoundLikeItemException(String message) {
+    public NotFoundLikeItemException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
@@ -5,8 +5,15 @@ import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikeItemRepository extends JpaRepository<LikeItem, Long> {
 
     Optional<LikeItem> findByUserAndItem(User user, Item item);
+
+    @Query("select li from LikeItem li"
+        + " join fetch li.user"
+        + " where li.likeItemId = :likeItemId")
+    Optional<LikeItem> findByIdWithUser(@Param("likeItemId") Long likeItemId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LikeItemRepository extends JpaRepository<LikeItem, Long> {
 
     Optional<LikeItem> findByUserAndItem(User user, Item item);
+
+    boolean existsByUserAndItem(User user, Item item);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
@@ -5,15 +5,8 @@ import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface LikeItemRepository extends JpaRepository<LikeItem, Long> {
 
     Optional<LikeItem> findByUserAndItem(User user, Item item);
-
-    @Query("select li from LikeItem li"
-        + " join fetch li.user"
-        + " where li.likeItemId = :likeItemId")
-    Optional<LikeItem> findByIdWithUser(@Param("likeItemId") Long likeItemId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
@@ -44,19 +44,19 @@ public class LikeItemService {
         likeItemRepository.delete(likeItem);
     }
 
-    private void checkDuplicateLikedItem(User user, Item item) {
+    private void checkDuplicateLikedItem(final User user, final Item item) {
         likeItemRepository.findByUserAndItem(user, item)
             .ifPresent(likeItem -> {
                 throw new DuplicateLikeItemException("이미 찜한 상품입니다.");
             });
     }
 
-    private User findUserByUserId(Long userId) {
+    private User findUserByUserId(final Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new NotFoundUserException("존재하지 않는 유저입니다."));
     }
 
-    private Item findItemByItemId(Long itemId) {
+    private Item findItemByItemId(final Long itemId) {
         return itemRepository.findById(itemId)
             .orElseThrow(() -> new NotFoundItemException("존재하지 않는 상품입니다."));
     }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
@@ -4,12 +4,15 @@ import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.exception.DuplicateLikeItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundItemException;
+import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
+import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +35,15 @@ public class LikeItemService {
         return likeItem.getLikeItemId();
     }
 
+    @Transactional
+    public void deleteLikeItem(DeleteLikeItemCommand deleteLikeItemCommand) {
+        LikeItem likeItem = findLikeItemByLikeItemId(deleteLikeItemCommand);
+        if (!likeItem.isSameUser(deleteLikeItemCommand.userId())) {
+            throw new AuthorizationException("권한이 없습니다.");
+        }
+        likeItemRepository.delete(likeItem);
+    }
+
     private void checkDuplicateLikedItem(User user, Item item) {
         likeItemRepository.findByUserAndItem(user, item)
             .ifPresent(likeItem -> {
@@ -47,5 +59,10 @@ public class LikeItemService {
     private Item findItemByItemId(Long itemId) {
         return itemRepository.findById(itemId)
             .orElseThrow(() -> new NotFoundItemException("존재하지 않는 상품입니다."));
+    }
+
+    private LikeItem findLikeItemByLikeItemId(DeleteLikeItemCommand deleteLikeItemCommand) {
+        return likeItemRepository.findById(deleteLikeItemCommand.likeItemId())
+            .orElseThrow(() -> new NotFoundLikeItemException("존재하지 않는 찜 상품입니다."));
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
@@ -45,10 +45,9 @@ public class LikeItemService {
     }
 
     private void checkDuplicateLikedItem(final User user, final Item item) {
-        likeItemRepository.findByUserAndItem(user, item)
-            .ifPresent(likeItem -> {
-                throw new DuplicateLikeItemException("이미 찜한 상품입니다.");
-            });
+        if (likeItemRepository.existsByUserAndItem(user, item)) {
+            throw new DuplicateLikeItemException("이미 찜한 상품입니다.");
+        }
     }
 
     private User findUserByUserId(final Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/request/DeleteLikeItemCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/request/DeleteLikeItemCommand.java
@@ -2,4 +2,7 @@ package com.prgrms.nabmart.domain.item.service.request;
 
 public record DeleteLikeItemCommand(Long userId, Long likeItemId) {
 
+    public static DeleteLikeItemCommand of(final Long userId, final Long likeItemId) {
+        return new DeleteLikeItemCommand(userId, likeItemId);
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/request/DeleteLikeItemCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/request/DeleteLikeItemCommand.java
@@ -1,0 +1,5 @@
+package com.prgrms.nabmart.domain.item.service.request;
+
+public record DeleteLikeItemCommand(Long userId, Long likeItemId) {
+
+}

--- a/src/main/java/com/prgrms/nabmart/domain/user/User.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/User.java
@@ -79,4 +79,8 @@ public class User extends BaseTimeEntity {
             throw new InvalidUserException("사용할 수 없는 이메일입니다.");
         }
     }
+
+    public boolean isSameUserId(Long userId) {
+        return this.userId.equals(userId);
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/User.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/User.java
@@ -80,7 +80,7 @@ public class User extends BaseTimeEntity {
         }
     }
 
-    public boolean isSameUserId(Long userId) {
+    public boolean isSameUserId(final Long userId) {
         return this.userId.equals(userId);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.global.auth.exception;
+
+public class AuthorizationException extends AuthException {
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.global.auth.exception;
 
 public class AuthorizationException extends AuthException {
 
-    public AuthorizationException(String message) {
+    public AuthorizationException(final String message) {
         super(message);
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/controller/LikeItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/controller/LikeItemControllerTest.java
@@ -5,9 +5,12 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,7 +26,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class LikeItemControllerTest extends BaseControllerTest {
 
     @Nested
-    @DisplayName("찜 아이템 API 호출 시")
+    @DisplayName("찜 아이템 등록 API 호출 시")
     class RegisterLikeItemTest {
 
         @Test
@@ -51,6 +54,34 @@ class LikeItemControllerTest extends BaseControllerTest {
                     ),
                     responseHeaders(
                         headerWithName("Location").description("리소스 접근 가능 경로")
+                    )
+                ));
+        }
+    }
+
+    @Nested
+    @DisplayName("찜 아이템 삭제 API 호출 시")
+    class DeleteLikeItemTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            //given
+            Long likeItemId = 1L;
+
+            //when
+            ResultActions resultActions = mockMvc.perform(delete(
+                "/api/v1/likes/{likeItemId}", likeItemId)
+                .header(AUTHORIZATION, accessToken));
+
+            //then
+            resultActions.andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName(AUTHORIZATION).description("액세스 토큰")
+                    ),
+                    pathParameters(
+                        parameterWithName("likeItemId").description("찜 상품 ID")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
@@ -12,14 +12,17 @@ import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.exception.DuplicateLikeItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundItemException;
+import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
+import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
+import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class LikeItemServiceTest {
@@ -46,14 +50,14 @@ class LikeItemServiceTest {
 
     MainCategory mainCategory = CategoryFixture.mainCategory();
     SubCategory subCategory = CategoryFixture.subCategory(mainCategory);
+    User user = UserFixture.user();
+    Item item = ItemFixture.item(mainCategory, subCategory);
+    LikeItem likeItem = ItemFixture.likeItem(user, item);
 
     @Nested
     @DisplayName("registerLikeItem 메서드 실행 시")
     class RegisterLikeItemTest {
 
-        User user = UserFixture.user();
-        Item item = ItemFixture.item(mainCategory, subCategory);
-        LikeItem likeItem = ItemFixture.likeItem(user, item);
         RegisterLikeItemCommand registerLikeItemCommand
             = RegisterLikeItemCommand.of(1L, 1L);
 
@@ -112,4 +116,54 @@ class LikeItemServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("deleteLikeItem 메서드 실행 시")
+    class DeleteLikeItemTest {
+
+        DeleteLikeItemCommand deleteLikeItemCommand = ItemFixture.deleteLikeItemCommand();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            ReflectionTestUtils.setField(user, "userId", 1L);
+
+            given(likeItemRepository.findById(any())).willReturn(Optional.ofNullable(likeItem));
+
+            //when
+            likeItemService.deleteLikeItem(deleteLikeItemCommand);
+
+            //then
+            then(likeItemRepository).should().delete(any());
+        }
+
+        @Test
+        @DisplayName("예외: 존재하지 않는 LikeItem")
+        void throwExceptionWhenNotFoundLikeItem() {
+            //given
+            given(likeItemRepository.findById(any())).willReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> likeItemService.deleteLikeItem(deleteLikeItemCommand))
+                .isInstanceOf(NotFoundLikeItemException.class);
+        }
+
+        @Test
+        @DisplayName("예외: LikeItem의 User와 일치하지 않는 userId")
+        void throwExceptionWhenNotEqualsUser() {
+            //given
+            Long userId = 1L;
+            Long notEqualsUserId = 2L;
+            ReflectionTestUtils.setField(user, "userId", userId);
+            DeleteLikeItemCommand notEqualsUserIdCommand
+                = new DeleteLikeItemCommand(notEqualsUserId, 1L);
+
+            given(likeItemRepository.findById(any())).willReturn(Optional.ofNullable(likeItem));
+
+            //when
+            assertThatThrownBy(() -> likeItemService.deleteLikeItem(notEqualsUserIdCommand))
+                .isInstanceOf(AuthorizationException.class);
+        }
+    }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
@@ -67,6 +67,8 @@ class LikeItemServiceTest {
             //given
             given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
             given(itemRepository.findById(any())).willReturn(Optional.ofNullable(item));
+            given(likeItemRepository.existsByUserAndItem(any(), any()))
+                .willReturn(false);
 
             //when
             likeItemService.registerLikeItem(registerLikeItemCommand);
@@ -106,8 +108,8 @@ class LikeItemServiceTest {
             //given
             given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
             given(itemRepository.findById(any())).willReturn(Optional.ofNullable(item));
-            given(likeItemRepository.findByUserAndItem(any(), any()))
-                .willReturn(Optional.ofNullable(likeItem));
+            given(likeItemRepository.existsByUserAndItem(any(), any()))
+                .willReturn(true);
 
             //when
             //then

--- a/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
@@ -5,6 +5,7 @@ import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
+import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse.FindItemResponse;
@@ -25,6 +26,8 @@ public final class ItemFixture {
     private static final int LIKE_COUNT = 0;
     private static final int RATE = 0;
     private static final int MAX_QUANTITY = 10;
+    private static final Long USER_ID = 1L;
+    private static final Long LIKE_ITEM_ID = 1L;
 
     public static Item item(MainCategory mainCategory, SubCategory subCategory) {
         return new Item(NAME, PRICE, DESCRIPTION, QUANTITY, DISCOUNT, MAX_QUANTITY, mainCategory,
@@ -47,5 +50,9 @@ public final class ItemFixture {
 
     public static RegisterLikeItemRequest registerLikeItemRequest() {
         return new RegisterLikeItemRequest(ITEM_ID);
+    }
+
+    public static DeleteLikeItemCommand deleteLikeItemCommand() {
+        return new DeleteLikeItemCommand(USER_ID, LIKE_ITEM_ID);
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 찜한 상품 제거 API를 추가하였습니다.


### 📝 작업 요약
- `LikeItemController`에 찜 상품 제거 API 추가
- `LikeItemService`에 찜 상품 제거 메서드 추가
  - 동일 유저 권한 검사를 위한 `AuthorizationException`을 `global/auth` 패키지에 추가


### 💡 관련 이슈
- [NAYB-100](https://naybmart.atlassian.net/browse/NAYB-100)


[NAYB-100]: https://naybmart.atlassian.net/browse/NAYB-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ