### PR TITLE
[NAYB-103] feat: 구매자는 찜한 상품 목록을 조회할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/LikeItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/LikeItemController.java
@@ -3,13 +3,17 @@ package com.prgrms.nabmart.domain.item.controller;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
 import com.prgrms.nabmart.domain.item.service.LikeItemService;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.global.auth.LoginUser;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,10 +43,19 @@ public class LikeItemController {
     @DeleteMapping("/{likeItemId}")
     public ResponseEntity<Void> deleteLikeItem(
         @PathVariable final Long likeItemId,
-        @LoginUser final Long userId
-    ) {
+        @LoginUser final Long userId) {
         DeleteLikeItemCommand deleteLikeItemCommand = DeleteLikeItemCommand.of(userId, likeItemId);
         likeItemService.deleteLikeItem(deleteLikeItemCommand);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<FindLikeItemsResponse> findLikeItems(
+        final Pageable pageable,
+        @LoginUser final Long userId) {
+        FindLikeItemsCommand findLikeItemsCommand = FindLikeItemsCommand.of(userId, pageable);
+        FindLikeItemsResponse findLikeItemsResponse
+            = likeItemService.findLikeItems(findLikeItemsCommand);
+        return ResponseEntity.ok(findLikeItemsResponse);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
@@ -3,12 +3,16 @@ package com.prgrms.nabmart.domain.item.repository;
 import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.user.User;
-import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikeItemRepository extends JpaRepository<LikeItem, Long> {
 
-    Optional<LikeItem> findByUserAndItem(User user, Item item);
-
     boolean existsByUserAndItem(User user, Item item);
+
+    @Query("select li from LikeItem li join fetch li.item where li.user = :user")
+    Page<LikeItem> findByUserWithItem(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
@@ -8,12 +8,15 @@ import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +51,14 @@ public class LikeItemService {
         if (likeItemRepository.existsByUserAndItem(user, item)) {
             throw new DuplicateLikeItemException("이미 찜한 상품입니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public FindLikeItemsResponse findLikeItems(FindLikeItemsCommand findLikeItemsCommand) {
+        User user = findUserByUserId(findLikeItemsCommand.userId());
+        Page<LikeItem> findLikeItemsPage
+            = likeItemRepository.findByUserWithItem(user, findLikeItemsCommand.pageable());
+        return FindLikeItemsResponse.from(findLikeItemsPage);
     }
 
     private User findUserByUserId(final Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindLikeItemsCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindLikeItemsCommand.java
@@ -1,0 +1,10 @@
+package com.prgrms.nabmart.domain.item.service.request;
+
+import org.springframework.data.domain.Pageable;
+
+public record FindLikeItemsCommand(Long userId, Pageable pageable) {
+
+    public static FindLikeItemsCommand of(Long userId, Pageable pageable) {
+        return new FindLikeItemsCommand(userId, pageable);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindLikeItemsCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindLikeItemsCommand.java
@@ -4,7 +4,7 @@ import org.springframework.data.domain.Pageable;
 
 public record FindLikeItemsCommand(Long userId, Pageable pageable) {
 
-    public static FindLikeItemsCommand of(Long userId, Pageable pageable) {
+    public static FindLikeItemsCommand of(final Long userId, final Pageable pageable) {
         return new FindLikeItemsCommand(userId, pageable);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindLikeItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindLikeItemsResponse.java
@@ -29,7 +29,7 @@ public record FindLikeItemsResponse(
         int like,
         double rate) {
 
-        public static FindLikeItemResponse from(LikeItem likeItem) {
+        public static FindLikeItemResponse from(final LikeItem likeItem) {
             Item item = likeItem.getItem();
             return new FindLikeItemResponse(
                 likeItem.getLikeItemId(),

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindLikeItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindLikeItemsResponse.java
@@ -1,0 +1,45 @@
+package com.prgrms.nabmart.domain.item.service.response;
+
+import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.LikeItem;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record FindLikeItemsResponse(
+    List<FindLikeItemResponse> items,
+    int page,
+    long totalElements) {
+
+    public static FindLikeItemsResponse from(final Page<LikeItem> likeItemPage) {
+        Page<FindLikeItemResponse> findLikeItemResponsePage
+            = likeItemPage.map(FindLikeItemResponse::from);
+        return new FindLikeItemsResponse(
+            findLikeItemResponsePage.getContent(),
+            findLikeItemResponsePage.getNumber(),
+            findLikeItemResponsePage.getTotalElements());
+    }
+
+    public record FindLikeItemResponse(
+        Long likeItemId,
+        Long itemId,
+        String name,
+        int price,
+        int discount,
+        int reviewCount,
+        int like,
+        double rate) {
+
+        public static FindLikeItemResponse from(LikeItem likeItem) {
+            Item item = likeItem.getItem();
+            return new FindLikeItemResponse(
+                likeItem.getLikeItemId(),
+                item.getItemId(),
+                item.getName(),
+                item.getPrice(),
+                item.getDiscount(),
+                item.getReviews().size(),
+                item.getLikeItems().size(),
+                item.getRate());
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/item/controller/LikeItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/controller/LikeItemControllerTest.java
@@ -6,16 +6,22 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.prgrms.nabmart.base.BaseControllerTest;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -65,7 +71,7 @@ class LikeItemControllerTest extends BaseControllerTest {
 
         @Test
         @DisplayName("성공")
-        void success() throws Exception {
+        void deleteLikeItem() throws Exception {
             //given
             Long likeItemId = 1L;
 
@@ -82,6 +88,54 @@ class LikeItemControllerTest extends BaseControllerTest {
                     ),
                     pathParameters(
                         parameterWithName("likeItemId").description("찜 상품 ID")
+                    )
+                ));
+        }
+    }
+
+    @Nested
+    @DisplayName("찜 아이템 목록 조회 API 호출 시")
+    class FindLikeItemsTest {
+
+        @Test
+        @DisplayName("성공")
+        void findLikeItems() throws Exception {
+            //given
+            int page = 0;
+            int size = 10;
+            FindLikeItemsResponse findLikeItemsResponse = ItemFixture.findLikeItemsResponse();
+
+            given(likeItemService.findLikeItems(any())).willReturn(findLikeItemsResponse);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/likes")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .header(AUTHORIZATION, accessToken)
+                .accept(MediaType.APPLICATION_JSON));
+
+            //then
+            resultActions.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                    queryParameters(
+                        parameterWithName("page").description("페이지"),
+                        parameterWithName("size").description("페이지 사이즈")
+                    ),
+                    requestHeaders(
+                        headerWithName(AUTHORIZATION).description("액세스 토큰")
+                    ),
+                    responseFields(
+                        fieldWithPath("items").type(ARRAY).description("찜 상품 목록"),
+                        fieldWithPath("items[].likeItemId").type(NUMBER).description("찜 상품 ID"),
+                        fieldWithPath("items[].itemId").type(NUMBER).description("상품 ID"),
+                        fieldWithPath("items[].name").type(STRING).description("상품 이름"),
+                        fieldWithPath("items[].price").type(NUMBER).description("상품 가격"),
+                        fieldWithPath("items[].discount").type(NUMBER).description("상품 할인 금액"),
+                        fieldWithPath("items[].reviewCount").type(NUMBER).description("리뷰 수"),
+                        fieldWithPath("items[].like").type(NUMBER).description("찜 수"),
+                        fieldWithPath("items[].rate").type(NUMBER).description("평점"),
+                        fieldWithPath("page").type(NUMBER).description("페이지"),
+                        fieldWithPath("totalElements").type(NUMBER).description("총 갯수")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
@@ -20,6 +20,7 @@ import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse.FindLikeItemResponse;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
@@ -36,8 +37,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class LikeItemServiceTest {
@@ -192,13 +193,13 @@ class LikeItemServiceTest {
             return likeItems;
         }
 
-        @Test
-        @DisplayName("성공")
-        void success() {
-            //given
-            List<LikeItem> likeItems = createLikeItems(3);
-            PageImpl<LikeItem> likeItemsPage = new PageImpl<>(likeItems);
+        List<LikeItem> likeItems = createLikeItems(3);
+        PageImpl<LikeItem> likeItemsPage = new PageImpl<>(likeItems);
 
+        @Test
+        @DisplayName("성공: 동일한 요소 개수, 페이지, 요소 총 개수")
+        void successValidFindLikeItemsResponse() {
+            //given
             given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
             given(likeItemRepository.findByUserWithItem(any(), any())).willReturn(likeItemsPage);
 
@@ -210,6 +211,27 @@ class LikeItemServiceTest {
             assertThat(findLikeItemsResponse.items()).hasSize(3);
             assertThat(findLikeItemsResponse.page()).isEqualTo(0);
             assertThat(findLikeItemsResponse.totalElements()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("성공: 동일한 단일 요소 값")
+        void successValidFindLikeItemResponse() {
+            //given
+            given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+            given(likeItemRepository.findByUserWithItem(any(), any())).willReturn(likeItemsPage);
+
+            //when
+            FindLikeItemsResponse findLikeItemsResponse
+                = likeItemService.findLikeItems(findLikeItemsCommand);
+
+            //then
+            List<FindLikeItemResponse> findLikeItemResponses = findLikeItemsResponse.items();
+            FindLikeItemResponse itemResponse = findLikeItemResponses.get(0);
+            LikeItem findLikeItem = likeItems.get(0);
+            assertThat(itemResponse.name()).isEqualTo(findLikeItem.getItem().getName());
+            assertThat(itemResponse.price()).isEqualTo(findLikeItem.getItem().getPrice());
+            assertThat(itemResponse.discount()).isEqualTo(findLikeItem.getItem().getDiscount());
+            assertThat(itemResponse.rate()).isEqualTo(findLikeItem.getItem().getRate());
         }
 
         @Test

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.item.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -16,13 +17,17 @@ import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.item.service.request.RegisterLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
 import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.data.domain.PageImpl;
 
 @ExtendWith(MockitoExtension.class)
 class LikeItemServiceTest {
@@ -164,8 +170,58 @@ class LikeItemServiceTest {
             given(likeItemRepository.findById(any())).willReturn(Optional.ofNullable(likeItem));
 
             //when
+            //then
             assertThatThrownBy(() -> likeItemService.deleteLikeItem(notEqualsUserIdCommand))
                 .isInstanceOf(AuthorizationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("FindLikeItems 메서드 실행 시")
+    class FindLikeItemsTest {
+
+        FindLikeItemsCommand findLikeItemsCommand = ItemFixture.findLikeItemsCommand();
+
+        private List<LikeItem> createLikeItems(int end) {
+            List<LikeItem> likeItems = new ArrayList<>();
+            for (int i = 0; i < end; i++) {
+                Item item = ItemFixture.item(mainCategory, subCategory);
+                LikeItem likeItem = ItemFixture.likeItem(user, item);
+                likeItems.add(likeItem);
+            }
+            return likeItems;
+        }
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            List<LikeItem> likeItems = createLikeItems(3);
+            PageImpl<LikeItem> likeItemsPage = new PageImpl<>(likeItems);
+
+            given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+            given(likeItemRepository.findByUserWithItem(any(), any())).willReturn(likeItemsPage);
+
+            //when
+            FindLikeItemsResponse findLikeItemsResponse
+                = likeItemService.findLikeItems(findLikeItemsCommand);
+
+            //then
+            assertThat(findLikeItemsResponse.items()).hasSize(3);
+            assertThat(findLikeItemsResponse.page()).isEqualTo(0);
+            assertThat(findLikeItemsResponse.totalElements()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("예외: 존재하지 않는 User")
+        void throwExceptionWhenNotFoundUser() {
+            //given
+            given(userRepository.findById(any())).willReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> likeItemService.findLikeItems(findLikeItemsCommand))
+                .isInstanceOf(NotFoundUserException.class);
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
@@ -3,15 +3,17 @@ package com.prgrms.nabmart.domain.item.support;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.ItemSortType;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
-import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
-import com.prgrms.nabmart.domain.user.User;
-import com.prgrms.nabmart.domain.item.ItemSortType;
 import com.prgrms.nabmart.domain.item.service.request.FindItemsByMainCategoryCommand;
+import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse.FindItemResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse.FindLikeItemResponse;
+import com.prgrms.nabmart.domain.user.User;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -70,5 +72,19 @@ public final class ItemFixture {
     public static FindLikeItemsCommand findLikeItemsCommand() {
         PageRequest pageRequest = PageRequest.of(0, 10);
         return new FindLikeItemsCommand(USER_ID, pageRequest);
+    }
+
+    public static FindLikeItemsResponse findLikeItemsResponse() {
+        FindLikeItemResponse findLikeItemResponse = new FindLikeItemResponse(
+            LIKE_ITEM_ID,
+            ITEM_ID,
+            NAME,
+            PRICE,
+            DISCOUNT,
+            REVIEW_COUNT,
+            LIKE_COUNT,
+            RATE
+        );
+        return new FindLikeItemsResponse(List.of(findLikeItemResponse), 0, 1);
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
@@ -6,6 +6,7 @@ import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterLikeItemRequest;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
+import com.prgrms.nabmart.domain.item.service.request.FindLikeItemsCommand;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.item.ItemSortType;
 import com.prgrms.nabmart.domain.item.service.request.FindItemsByMainCategoryCommand;
@@ -14,6 +15,7 @@ import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse.FindIte
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ItemFixture {
@@ -63,5 +65,10 @@ public final class ItemFixture {
 
     public static DeleteLikeItemCommand deleteLikeItemCommand() {
         return new DeleteLikeItemCommand(USER_ID, LIKE_ITEM_ID);
+    }
+
+    public static FindLikeItemsCommand findLikeItemsCommand() {
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        return new FindLikeItemsCommand(USER_ID, pageRequest);
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 찜 상품 목록 조회 API를 추가하였습니다.
- 페이지, 페이지 사이즈 정보를 받아 로그인한 사용자의 찜 상품 목록을 반환합니다.


### 📝 작업 요약
- 찜 상품 목록 조회 API 추가
- 테스트 추가


### 💡 관련 이슈
- [NAYB-103](https://naybmart.atlassian.net/browse/NAYB-103)


[NAYB-103]: https://naybmart.atlassian.net/browse/NAYB-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ