### PR TITLE
[NAYB-114] fix: `Delivery` 생성 시 주소지 길이 검증 로직 수정

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -51,7 +51,7 @@ public class Delivery {
     }
 
     private void validateAddress(String address) {
-        if (nonNull(address)) {
+        if (nonNull(address) && address.length() > ADDRESS_LENGTH) {
             throw new InvalidDeliveryException("주소의 길이는 500자를 넘을 수 없습니다.");
         }
     }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.delivery;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
@@ -20,6 +21,26 @@ class DeliveryTest {
 
         User user = UserFixture.user();
         Order order = OrderFixture.getDeliveringOrder(1L, user);
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            String address = "주소지";
+            LocalDateTime finishedTime = LocalDateTime.now();
+
+            //when
+            Delivery delivery = Delivery.builder()
+                .order(order)
+                .address(address)
+                .finishedTime(finishedTime)
+                .build();
+
+            //then
+            assertThat(delivery.getAddress()).isEqualTo(address);
+            assertThat(delivery.getFinishedTime()).isEqualTo(finishedTime);
+            assertThat(delivery.getOrder()).isEqualTo(order);
+        }
 
         @Test
         @DisplayName("예외: 주소 길이가 500자를 초과")


### PR DESCRIPTION
### ⛏ 작업 사항
- `Delivery` 생성 시 주소지 길이 검증 로직에 오류가 있던 것을 수정하였습니다.
- 검증 메서드에서 null이 아닌지만 검증하고 길이를 검증하지 않던 문제가 있었습니다. 이전 PR에 제대로 반영되지 않아 다시 PR합니다..!


### 📝 작업 요약
- `Delivery` `validateAddress()` 메서드 수


### 💡 관련 이슈
- [NAYB-114](https://naybmart.atlassian.net/browse/NAYB-114)



[NAYB-114]: https://naybmart.atlassian.net/browse/NAYB-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ