### PR TITLE
[NAYB-90] chore: PR시 리뷰어 자동 배정 설정 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.java @pushedrumex @funnysunny08 @seongHyun-Min @Seongju-Lee @bjo6300 @hseong3243


### PR DESCRIPTION
### ⛏ 작업 사항
- PR시 리뷰어 자동 배정하는 설정을 추가했습니다.
- 해당 설정은 이번 PR이 머지된 이후부터 적용됩니다.
  - 처음 적용해보는 것이라서 안 될 수도 있습니다.


### 📝 작업 요약
- `.github/CODEOWNERS` 추가


### 💡 관련 이슈
- [NAYB-90](https://naybmart.atlassian.net/browse/NAYB-90)


[NAYB-90]: https://naybmart.atlassian.net/browse/NAYB-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ