### PR TITLE
[NAYB-116] feat: 다중 인스턴스 환경에서 스케줄러를 통한 업데이트 작업이 하나의 인스턴스에서만 수행되도록 변경한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //scheduler
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.7.0'
+
     // db
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     //scheduler
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.7.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.7.0'
 
     // db
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
@@ -3,8 +3,8 @@ package com.prgrms.nabmart.domain.user.service;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.prgrms.nabmart.domain.user.UserGrade;
-import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -12,13 +12,18 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@EnableSchedulerLock(defaultLockAtMostFor = "PT60S")
 public class GradeService {
 
     private static final int ONE = 1;
@@ -29,6 +34,7 @@ public class GradeService {
 
     @Async
     @Scheduled(cron = "0 0 5 1 * *")
+    @SchedulerLock(name = "Update_User_Grade", lockAtLeastFor = "PT10S")
     @Transactional
     public void updateUserGrade() {
         long totalUserCount = userRepository.count();

--- a/src/main/java/com/prgrms/nabmart/global/config/ScheduledConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/ScheduledConfig.java
@@ -1,5 +1,9 @@
 package com.prgrms.nabmart.global.config;
 
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,7 +16,6 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @EnableScheduling
 public class ScheduledConfig implements SchedulingConfigurer {
 
-
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
         ThreadPoolTaskScheduler threadPool = new ThreadPoolTaskScheduler();
@@ -22,6 +25,11 @@ public class ScheduledConfig implements SchedulingConfigurer {
         threadPool.initialize();
 
         taskRegistrar.setTaskScheduler(threadPool);
+    }
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(dataSource);
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
 
   sql:
     init:
-      schema-locations: classpath:sql/oauth2-client-schema.sql
+      schema-locations: classpath:sql/oauth2-client-schema.sql, classpath:sql/shedlock-schema.sql
       encoding: UTF-8
       mode: always
 

--- a/src/main/resources/sql/shedlock-schema.sql
+++ b/src/main/resources/sql/shedlock-schema.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS shedlock;
+CREATE TABLE shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);


### PR DESCRIPTION
### ⛏ 작업 사항
- 분산 환경에서 동시에 한 번의 스케줄링 작업이 수행되도록 스케줄러 락을 추가하였습니다.
- 등급 업데이트 작업에 스케줄러 락을 적용하였습니다.


### 📝 작업 요약
- 스케줄러 락을 위한 라이브러리 `shedlock` 추가
- `GradeService` 스케줄러 락 적


### 💡 관련 이슈
- [NAYB-116](https://naybmart.atlassian.net/browse/NAYB-116)



[NAYB-116]: https://naybmart.atlassian.net/browse/NAYB-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ