### PR TITLE
[NAYB-120] feat: 라이더는 회원가입을 할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
@@ -29,7 +29,7 @@ public class Rider {
     private String address;
 
     @Builder
-    public Rider(String username, String password, String address) {
+    public Rider(final String username, final String password, final String address) {
         this.username = username;
         this.password = password;
         this.address = address;

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
@@ -1,10 +1,14 @@
 package com.prgrms.nabmart.domain.delivery;
 
+import static java.util.Objects.nonNull;
+
+import com.prgrms.nabmart.domain.delivery.exception.InvalidRiderException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +18,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Rider {
+
+    private static final Pattern USERNAME_PATTERN
+        = Pattern.compile("^(?=.*[a-z])[a-z0-9]{6,20}$");
+    private static final int PASSWORD_LENGTH = 1000;
+    private static final int ADDRESS_LENGTH = 200;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,8 +39,30 @@ public class Rider {
 
     @Builder
     public Rider(final String username, final String password, final String address) {
+        validateUsername(username);
+        validatePassword(password);
+        validateAddress(address);
         this.username = username;
         this.password = password;
         this.address = address;
+    }
+
+    private void validateUsername(String username) {
+        if (nonNull(username) && !USERNAME_PATTERN.matcher(username).matches()) {
+            throw new InvalidRiderException(
+                "사용자 이름은 영어 소문자 또는 영어 소문자와 숫자 6자 이상, 20자 이하로 구성 되어야 합니다.");
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (nonNull(password) && password.length() > PASSWORD_LENGTH) {
+            throw new InvalidRiderException("유효하지 않은 패스워드 입니다.");
+        }
+    }
+
+    private void validateAddress(String address) {
+        if (nonNull(address) && address.length() > ADDRESS_LENGTH) {
+            throw new InvalidRiderException("주소의 길이는 최대 200자 입니다.");
+        }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
@@ -1,0 +1,37 @@
+package com.prgrms.nabmart.domain.delivery;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Rider {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long riderId;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Builder
+    public Rider(String username, String password, String address) {
+        this.username = username;
+        this.password = password;
+        this.address = address;
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/RiderController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/RiderController.java
@@ -1,0 +1,34 @@
+package com.prgrms.nabmart.domain.delivery.controller;
+
+import com.prgrms.nabmart.domain.delivery.controller.request.RiderSignupRequest;
+import com.prgrms.nabmart.domain.delivery.service.RiderService;
+import com.prgrms.nabmart.domain.delivery.service.request.RiderSignupCommand;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/riders")
+public class RiderController {
+
+    private static final String BASE_URL = "/api/v1/riders/";
+
+    private final RiderService riderService;
+
+    @PostMapping
+    public ResponseEntity<Void> riderSignup(@RequestBody @Valid RiderSignupRequest riderSignupRequest) {
+        RiderSignupCommand riderSignupCommand = RiderSignupCommand.of(
+            riderSignupRequest.username(),
+            riderSignupRequest.password(),
+            riderSignupRequest.address());
+        Long riderId = riderService.riderSignup(riderSignupCommand);
+        URI location = URI.create(BASE_URL + riderId);
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/request/RiderSignupRequest.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/request/RiderSignupRequest.java
@@ -1,0 +1,21 @@
+package com.prgrms.nabmart.domain.delivery.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RiderSignupRequest(
+    @NotNull(message = "사용자 이름은 필수 입니다.")
+    @Pattern(regexp = "^(?=.*[a-z])[a-z0-9]{6,20}$",
+        message = "사용자 이름은 영어 소문자 또는 영어 소문자와 숫자 6자 이상, 20자 이하로 구성 되어야 합니다.")
+    String username,
+    @NotNull(message = "패스워드는 필수 입니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,20}$",
+        message = "패스워드는 영어 소문자, 숫자 8자 이상, 20자 이하로 구성 되어야 합니다.")
+    String password,
+    @NotBlank(message = "주소는 필수 입니다.")
+    @Size(max = 200, message = "주소의 길이는 최대 200자 입니다.")
+    String address) {
+
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/DuplicateRiderUsernameException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/DuplicateRiderUsernameException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public class DuplicateRiderUsernameException extends RiderException {
+
+    public DuplicateRiderUsernameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidRiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidRiderException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public class InvalidRiderException extends RiderException {
+
+    public InvalidRiderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/RiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/RiderException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public abstract class RiderException extends RuntimeException {
+
+    protected RiderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/RiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/RiderException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public abstract class RiderException extends RuntimeException {
 
-    protected RiderException(String message) {
+    protected RiderException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/RiderRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/RiderRepository.java
@@ -1,0 +1,9 @@
+package com.prgrms.nabmart.domain.delivery.repository;
+
+import com.prgrms.nabmart.domain.delivery.Rider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RiderRepository extends JpaRepository<Rider, Long> {
+
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/RiderService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/RiderService.java
@@ -1,0 +1,41 @@
+package com.prgrms.nabmart.domain.delivery.service;
+
+import com.prgrms.nabmart.domain.delivery.Rider;
+import com.prgrms.nabmart.domain.delivery.exception.DuplicateRiderUsernameException;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
+import com.prgrms.nabmart.domain.delivery.service.request.RiderSignupCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RiderService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final RiderRepository riderRepository;
+
+    @Transactional
+    public Long riderSignup(RiderSignupCommand riderSignupCommand) {
+        checkUsernameDuplication(riderSignupCommand.username());
+        Rider rider = createRider(riderSignupCommand);
+        riderRepository.save(rider);
+        return rider.getRiderId();
+    }
+
+    private void checkUsernameDuplication(final String username) {
+        if (riderRepository.existsByUsername(username)) {
+            throw new DuplicateRiderUsernameException("사용할 수 없는 아이디입니다.");
+        }
+    }
+
+    private Rider createRider(RiderSignupCommand riderSignupCommand) {
+        String encodedPassword = passwordEncoder.encode(riderSignupCommand.password());
+        return Rider.builder()
+            .username(riderSignupCommand.username())
+            .password(encodedPassword)
+            .address(riderSignupCommand.address())
+            .build();
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/RiderSignupCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/RiderSignupCommand.java
@@ -2,4 +2,10 @@ package com.prgrms.nabmart.domain.delivery.service.request;
 
 public record RiderSignupCommand(String username, String password, String address) {
 
+    public static RiderSignupCommand of(
+        final String username,
+        final String password,
+        final String address) {
+        return new RiderSignupCommand(username, password, address);
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/RiderSignupCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/RiderSignupCommand.java
@@ -1,0 +1,5 @@
+package com.prgrms.nabmart.domain.delivery.service.request;
+
+public record RiderSignupCommand(String username, String password, String address) {
+
+}

--- a/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.JdbcOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -49,5 +51,10 @@ public class WebSecurityConfig {
             .addFilterAfter(new JwtAuthenticationFilter(jwtAuthenticationProvider),
                 SecurityContextHolderFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -7,6 +7,7 @@ import com.prgrms.nabmart.domain.cart.service.CartItemService;
 import com.prgrms.nabmart.domain.category.service.CategoryService;
 import com.prgrms.nabmart.domain.coupon.service.CouponService;
 import com.prgrms.nabmart.domain.delivery.service.DeliveryService;
+import com.prgrms.nabmart.domain.delivery.service.RiderService;
 import com.prgrms.nabmart.domain.event.service.EventItemService;
 import com.prgrms.nabmart.domain.event.service.EventService;
 import com.prgrms.nabmart.domain.item.service.ItemService;
@@ -87,6 +88,9 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected OrderService orderService;
+
+    @MockBean
+    protected RiderService riderService;
 
     protected static final String AUTHORIZATION = "Authorization";
 

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/RiderTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/RiderTest.java
@@ -1,0 +1,136 @@
+package com.prgrms.nabmart.domain.delivery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.prgrms.nabmart.domain.delivery.Rider.RiderBuilder;
+import com.prgrms.nabmart.domain.delivery.exception.InvalidRiderException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RiderTest {
+
+    String username = "username";
+    String password = "password123";
+    String address = "address";
+
+    @Nested
+    @DisplayName("username 검증 시")
+    class UsernameTest {
+
+        @ParameterizedTest
+        @CsvSource({
+            "member", "user123"
+        })
+        @DisplayName("성공")
+        void success(String validUsername) {
+            //given
+            //when
+            Rider rider = Rider.builder()
+                .username(validUsername)
+                .password(password)
+                .address(address)
+                .build();
+
+            //then
+            assertThat(rider.getUsername()).isEqualTo(validUsername);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "user1", "UPPERCase", "123", "user!@#"
+        })
+        @DisplayName("예외: 유효하지 않은 사용자 이름")
+        void throwExceptionWhenInvalidUsername(String invalidUsername) {
+            //given
+            //when
+            RiderBuilder riderBuilder = Rider.builder()
+                .username(invalidUsername)
+                .password(password)
+                .address(address);
+
+            //then
+            assertThatThrownBy(riderBuilder::build).isInstanceOf(InvalidRiderException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("password 검증 시")
+    class PasswordTest {
+
+        @ParameterizedTest
+        @CsvSource({
+            "password123", "word1234"
+        })
+        @DisplayName("성공")
+        void success(String validPassword) {
+            //given
+            //when
+            Rider rider = Rider.builder()
+                .username(username)
+                .password(validPassword)
+                .address(address)
+                .build();
+
+            //then
+            assertThat(rider.getPassword()).isEqualTo(validPassword);
+        }
+
+        @Test
+        @DisplayName("예외: 패스워드가 1000자를 초과")
+        void throwExceptionWhenPasswordIsNull() {
+            //given
+            String invalidPassword = "a".repeat(1001);
+
+            //when
+            RiderBuilder riderBuilder = Rider.builder()
+                .username(username)
+                .password(invalidPassword)
+                .address(address);
+
+            //then
+            assertThatThrownBy(riderBuilder::build).isInstanceOf(InvalidRiderException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("address 검증 시")
+    class AddressTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            String validAddress = "address";
+
+            //when
+            Rider rider = Rider.builder()
+                .username(username)
+                .password(password)
+                .address(validAddress)
+                .build();
+
+            //then
+            assertThat(rider.getAddress()).isEqualTo(validAddress);
+        }
+
+        @Test
+        @DisplayName("예외: 주소 길이가 200자를 초과")
+        void throwExceptionWhenAddressHasInvalidLength() {
+            //given
+            String invalidAddress = "a".repeat(201);
+
+            //when
+            RiderBuilder riderBuilder = Rider.builder()
+                .username(username)
+                .password(password)
+                .address(invalidAddress);
+
+            //then
+            assertThatThrownBy(riderBuilder::build).isInstanceOf(InvalidRiderException.class);
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/RiderControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/RiderControllerTest.java
@@ -1,0 +1,59 @@
+package com.prgrms.nabmart.domain.delivery.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.nabmart.base.BaseControllerTest;
+import com.prgrms.nabmart.domain.delivery.controller.request.RiderSignupRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class RiderControllerTest extends BaseControllerTest {
+
+    @Nested
+    @DisplayName("라이더 가입 API 호출 시")
+    class RiderSignupTest {
+
+        @Test
+        @DisplayName("성공")
+        void riderSignup() throws Exception {
+            //given
+            String username = "username";
+            String password = "password123";
+            String address = "address";
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, password, address);
+            Long riderId = 1L;
+
+            given(riderService.riderSignup(any())).willReturn(riderId);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(post("/api/v1/riders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(riderSignupRequest)));
+
+            //then
+            resultActions.andExpect(status().isCreated())
+                .andDo(restDocs.document(
+                    requestFields(
+                        fieldWithPath("username").type(STRING).description("사용자 이름"),
+                        fieldWithPath("password").type(STRING).description("패스워드"),
+                        fieldWithPath("address").type(STRING).description("배달 선호 주소")
+                    ),
+                    responseHeaders(
+                        headerWithName("Location").description("생성된 리소스 접근 경로")
+                    )
+                ));
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/request/RiderSignupRequestTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/request/RiderSignupRequestTest.java
@@ -1,0 +1,221 @@
+package com.prgrms.nabmart.domain.delivery.controller.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RiderSignupRequestTest {
+
+    private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    private final Validator validator = factory.getValidator();
+
+    String username = "username";
+    String password = "password123";
+    String address = "address";
+
+    @Nested
+    @DisplayName("username 검증 시")
+    class UsernameTes {
+
+        @ParameterizedTest
+        @CsvSource({
+            "member", "user123"
+        })
+        @DisplayName("성공")
+        void success(String validUsername) {
+            //given
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(validUsername, password, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(0);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "user1", "UPPERCase", "123", "user!@#"
+        })
+        @DisplayName("예외: 유효하지 않은 사용자 이름")
+        void throwExceptionWhenInvalidUsername(String invalidUsername) {
+            //given
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(invalidUsername, password, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnly(invalidUsername);
+        }
+
+        @Test
+        @DisplayName("예외: 사용자 이름이 null")
+        void throwExceptionWhenUsernameIsNull() {
+            //given
+            String nullUsername = null;
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(nullUsername, password, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnlyNulls();
+        }
+    }
+
+    @Nested
+    @DisplayName("password 검증 시")
+    class PasswordTest {
+
+        @ParameterizedTest
+        @CsvSource({
+            "password123", "word1234"
+        })
+        @DisplayName("성공")
+        void success(String validPassword) {
+            //given
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, validPassword, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(0);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            "password", "UPPERCase123", "1234", "password!@#$%"
+        })
+        @DisplayName("예외: 유효하지 않은 패스워드")
+        void throwExceptionWhenInvalidPassword(String invalidPassword) {
+            //given
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, invalidPassword, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnly(invalidPassword);
+        }
+
+        @Test
+        @DisplayName("예외: 패스워드가 null")
+        void throwExceptionWhenPasswordIsNull() {
+            //given
+            String nullPassword = null;
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, nullPassword, address);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnlyNulls();
+        }
+    }
+
+    @Nested
+    @DisplayName("address 검증 시")
+    class AddressTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            String validAddress = "address";
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, password, validAddress);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(0);
+        }
+
+        @Test
+        @DisplayName("예외: 주소 길이가 200자를 초과")
+        void throwExceptionWhenAddressHasInvalidLength() {
+            //given
+            String invalidAddress = "a".repeat(201);
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, password, invalidAddress);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnly(invalidAddress);
+        }
+
+        @Test
+        @DisplayName("예외: 주소가 공백")
+        void throwExceptionWhenAddressIsBlank() {
+            //given
+            String invalidAddress = "  ";
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, password, invalidAddress);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnly(invalidAddress);
+        }
+
+        @Test
+        @DisplayName("예외: 주소가 null")
+        void throwExceptionWhenAddressIsNull() {
+            //given
+            String nullAddress = null;
+            RiderSignupRequest riderSignupRequest
+                = new RiderSignupRequest(username, password, nullAddress);
+
+            //when
+            Set<ConstraintViolation<RiderSignupRequest>> result
+                = validator.validate(riderSignupRequest);
+
+            //then
+            assertThat(result).hasSize(1);
+            assertThat(result).map(ConstraintViolation::getInvalidValue)
+                .containsOnlyNulls();
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/RiderServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/RiderServiceTest.java
@@ -1,0 +1,81 @@
+package com.prgrms.nabmart.domain.delivery.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.prgrms.nabmart.domain.delivery.exception.DuplicateRiderUsernameException;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
+import com.prgrms.nabmart.domain.delivery.service.request.RiderSignupCommand;
+import com.prgrms.nabmart.domain.delivery.support.RiderFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class RiderServiceTest {
+
+    @InjectMocks
+    RiderService riderService;
+
+    @Mock
+    RiderRepository riderRepository;
+
+    @Spy
+    PasswordEncoder passwordEncoder;
+
+    public RiderServiceTest() {
+        passwordEncoder = mockPasswordEncoder;
+    }
+
+    PasswordEncoder mockPasswordEncoder = new PasswordEncoder() {
+        @Override
+        public String encode(CharSequence rawPassword) {
+            return new StringBuilder(rawPassword).reverse().toString();
+        }
+
+        @Override
+        public boolean matches(CharSequence rawPassword, String encodedPassword) {
+            return encode(rawPassword).equals(encodedPassword);
+        }
+    };
+
+    @Nested
+    @DisplayName("riderSignup 메서드 실행 시")
+    class RiderSignupTest {
+
+        RiderSignupCommand riderSignupCommand = RiderFixture.riderSignupCommand();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            given(riderRepository.existsByUsername(any())).willReturn(false);
+
+            //when
+            riderService.riderSignup(riderSignupCommand);
+
+            //then
+            then(riderRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("예외: 중복된 사용자 이름")
+        void throwExceptionWhenUsernameDuplicate() {
+            //given
+            given(riderRepository.existsByUsername(any())).willReturn(true);
+
+            //when
+            //then
+            assertThatThrownBy(() -> riderService.riderSignup(riderSignupCommand))
+                .isInstanceOf(DuplicateRiderUsernameException.class);
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/RiderFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/RiderFixture.java
@@ -1,0 +1,17 @@
+package com.prgrms.nabmart.domain.delivery.support;
+
+import com.prgrms.nabmart.domain.delivery.service.request.RiderSignupCommand;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RiderFixture {
+
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String ADDRESS = "address";
+
+    public static RiderSignupCommand riderSignupCommand() {
+        return new RiderSignupCommand(USERNAME, PASSWORD, ADDRESS);
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 라이더 엔티티를 추가하였습니다.
- 라이더 회원가입 API를 추가하였습니다.
- 라이더는 기존 회원과 달리 소셜 로그인을 이용하지 않습니다. 아이디와 패스워드를 받아 회원가입 및 로그인을 진행할 예정입니다.


### 📝 작업 요약
- `delivery` 패키지에 라이더 엔티티와 관련 클래스들을 추가하였습니다.
- 컨트롤러, 서비스, 리포지토리 메서드 및 테스트를 작성하였습니다.


### 💡 관련 이슈
- [NAYB-120](https://naybmart.atlassian.net/browse/NAYB-120)



[NAYB-120]: https://naybmart.atlassian.net/browse/NAYB-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ