### PR TITLE
[NAYB-122] feat: 기존 배달 도메인에 라이더 추가 반영

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -3,6 +3,7 @@ package com.prgrms.nabmart.domain.delivery;
 import static java.util.Objects.nonNull;
 
 import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
+import com.prgrms.nabmart.domain.delivery.exception.UnauthorizedDeliveryException;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.user.User;
 import jakarta.persistence.Column;
@@ -85,5 +86,15 @@ public class Delivery {
     public void completeDelivery() {
         this.arrivedAt = LocalDateTime.now();
         this.deliveryStatus = DeliveryStatus.DELIVERED;
+    }
+
+    public void checkAuthority(Rider rider) {
+        if (!this.rider.equals(rider)) {
+            throw new UnauthorizedDeliveryException("권한이 없습니다.");
+        }
+    }
+
+    public void acceptDelivery(Rider rider) {
+        this.rider = rider;
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -33,6 +34,10 @@ public class Delivery {
     @OneToOne
     @JoinColumn(name = "orderId", nullable = false)
     private Order order;
+
+    @ManyToOne
+    @JoinColumn(name = "riderId")
+    private Rider rider;
 
     @Column(nullable = false)
     private DeliveryStatus deliveryStatus;

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -4,6 +4,7 @@ import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.UnauthorizedDeliveryException;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.global.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Delivery {
+public class Delivery extends BaseTimeEntity {
 
     private static final int ADDRESS_LENGTH = 500;
     private static final int ZERO = 0;

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -71,7 +71,7 @@ public class Delivery {
         this.deliveryStatus = DeliveryStatus.DELIVERED;
     }
 
-    public void checkAuthority(Rider rider) {
+    public void checkAuthority(final Rider rider) {
         if (!this.rider.equals(rider)) {
             throw new UnauthorizedDeliveryException("권한이 없습니다.");
         }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -1,7 +1,5 @@
 package com.prgrms.nabmart.domain.delivery;
 
-import static java.util.Objects.nonNull;
-
 import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.UnauthorizedDeliveryException;
 import com.prgrms.nabmart.domain.order.Order;
@@ -46,25 +44,10 @@ public class Delivery {
     @Column
     private LocalDateTime arrivedAt;
 
-    @Column(nullable = false)
-    private String address;
-
-    @Column(nullable = false)
-    private int deliveryFee;
-
     @Builder
-    public Delivery(final Order order, final String address, final int deliveryFee) {
-        validateAddress(address);
+    public Delivery(final Order order) {
         this.order = order;
-        this.address = address;
-        this.deliveryFee = deliveryFee;
         this.deliveryStatus = DeliveryStatus.ACCEPTING_ORDER;
-    }
-
-    private void validateAddress(final String address) {
-        if (nonNull(address) && address.length() > ADDRESS_LENGTH) {
-            throw new InvalidDeliveryException("주소의 길이는 500자를 넘을 수 없습니다.");
-        }
     }
 
     public boolean isOwnByUser(final User user) {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
@@ -3,6 +3,7 @@ package com.prgrms.nabmart.domain.delivery;
 import static java.util.Objects.nonNull;
 
 import com.prgrms.nabmart.domain.delivery.exception.InvalidRiderException;
+import com.prgrms.nabmart.global.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Rider {
+public class Rider extends BaseTimeEntity {
 
     private static final Pattern USERNAME_PATTERN
         = Pattern.compile("^(?=.*[a-z])[a-z0-9]{6,20}$");

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Rider.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -64,5 +65,22 @@ public class Rider {
         if (nonNull(address) && address.length() > ADDRESS_LENGTH) {
             throw new InvalidRiderException("주소의 길이는 최대 200자 입니다.");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Rider rider = (Rider) o;
+        return Objects.equals(username, rider.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -41,7 +41,7 @@ public class DeliveryController {
     public ResponseEntity<Void> startDelivery(
         @PathVariable final Long deliveryId,
         @RequestBody @Valid StartDeliveryRequest startDeliveryRequest,
-        @LoginUser Long riderId) {
+        @LoginUser final Long riderId) {
         StartDeliveryCommand startDeliveryCommand = StartDeliveryCommand.of(
             deliveryId,
             startDeliveryRequest.deliveryEstimateMinutes(),

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -51,8 +51,11 @@ public class DeliveryController {
     }
 
     @PatchMapping("/complete/{deliveryId}")
-    public ResponseEntity<Void> completeDelivery(@PathVariable final Long deliveryId) {
-        CompleteDeliveryCommand completeDeliveryCommand = CompleteDeliveryCommand.from(deliveryId);
+    public ResponseEntity<Void> completeDelivery(
+        @PathVariable final Long deliveryId,
+        @LoginUser final Long riderId) {
+        CompleteDeliveryCommand completeDeliveryCommand
+            = CompleteDeliveryCommand.of(deliveryId, riderId);
         deliveryService.completeDelivery(completeDeliveryCommand);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -40,10 +40,12 @@ public class DeliveryController {
     @PatchMapping("/pickup/{deliveryId}")
     public ResponseEntity<Void> startDelivery(
         @PathVariable final Long deliveryId,
-        @RequestBody @Valid StartDeliveryRequest startDeliveryRequest) {
+        @RequestBody @Valid StartDeliveryRequest startDeliveryRequest,
+        @LoginUser Long riderId) {
         StartDeliveryCommand startDeliveryCommand = StartDeliveryCommand.of(
             deliveryId,
-            startDeliveryRequest.deliveryEstimateMinutes());
+            startDeliveryRequest.deliveryEstimateMinutes(),
+            riderId);
         deliveryService.startDelivery(startDeliveryCommand);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/DeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/DeliveryException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public abstract class DeliveryException extends RuntimeException {
 
-    protected DeliveryException(String message) {
+    protected DeliveryException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidDeliveryException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class InvalidDeliveryException extends DeliveryException {
 
-    public InvalidDeliveryException(String message) {
+    public InvalidDeliveryException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidRiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/InvalidRiderException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class InvalidRiderException extends RiderException {
 
-    public InvalidRiderException(String message) {
+    public InvalidRiderException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundDeliveryException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class NotFoundDeliveryException extends DeliveryException {
 
-    public NotFoundDeliveryException(String message) {
+    public NotFoundDeliveryException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundRiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundRiderException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public class NotFoundRiderException extends RiderException {
+
+    public NotFoundRiderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundRiderException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/NotFoundRiderException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class NotFoundRiderException extends RiderException {
 
-    public NotFoundRiderException(String message) {
+    public NotFoundRiderException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/UnauthorizedDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/UnauthorizedDeliveryException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public class UnauthorizedDeliveryException extends DeliveryException{
+
+    public UnauthorizedDeliveryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/UnauthorizedDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/UnauthorizedDeliveryException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class UnauthorizedDeliveryException extends DeliveryException{
 
-    public UnauthorizedDeliveryException(String message) {
+    public UnauthorizedDeliveryException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
@@ -1,8 +1,11 @@
 package com.prgrms.nabmart.domain.delivery.service;
 
 import com.prgrms.nabmart.domain.delivery.Delivery;
+import com.prgrms.nabmart.domain.delivery.Rider;
 import com.prgrms.nabmart.domain.delivery.exception.NotFoundDeliveryException;
+import com.prgrms.nabmart.domain.delivery.exception.NotFoundRiderException;
 import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
 import com.prgrms.nabmart.domain.delivery.service.request.CompleteDeliveryCommand;
 import com.prgrms.nabmart.domain.delivery.service.request.FindWaitingDeliveriesCommand;
 import com.prgrms.nabmart.domain.delivery.service.request.FindDeliveryCommand;
@@ -24,6 +27,7 @@ public class DeliveryService {
 
     private final DeliveryRepository deliveryRepository;
     private final UserRepository userRepository;
+    private final RiderRepository riderRepository;
 
     @Transactional(readOnly = true)
     public FindDeliveryDetailResponse findDelivery(FindDeliveryCommand findDeliveryCommand) {
@@ -41,8 +45,15 @@ public class DeliveryService {
 
     @Transactional
     public void startDelivery(StartDeliveryCommand startDeliveryCommand) {
+        Rider rider = findRiderByRiderId(startDeliveryCommand.riderId());
         Delivery delivery = findDeliveryByDeliveryId(startDeliveryCommand.deliveryId());
+        delivery.checkAuthority(rider);
         delivery.startDelivery(startDeliveryCommand.deliveryEstimateMinutes());
+    }
+
+    private Rider findRiderByRiderId(Long riderId) {
+        return riderRepository.findById(riderId)
+            .orElseThrow(() -> new NotFoundRiderException("존재하지 않는 라이더입니다."));
     }
 
     @Transactional

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
@@ -59,7 +59,7 @@ public class DeliveryService {
         delivery.completeDelivery();
     }
 
-    private Rider findRiderByRiderId(Long riderId) {
+    private Rider findRiderByRiderId(final Long riderId) {
         return riderRepository.findById(riderId)
             .orElseThrow(() -> new NotFoundRiderException("존재하지 않는 라이더입니다."));
     }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
@@ -51,15 +51,17 @@ public class DeliveryService {
         delivery.startDelivery(startDeliveryCommand.deliveryEstimateMinutes());
     }
 
+    @Transactional
+    public void completeDelivery(CompleteDeliveryCommand completeDeliveryCommand) {
+        Rider rider = findRiderByRiderId(completeDeliveryCommand.riderId());
+        Delivery delivery = findDeliveryByDeliveryId(completeDeliveryCommand.deliveryId());
+        delivery.checkAuthority(rider);
+        delivery.completeDelivery();
+    }
+
     private Rider findRiderByRiderId(Long riderId) {
         return riderRepository.findById(riderId)
             .orElseThrow(() -> new NotFoundRiderException("존재하지 않는 라이더입니다."));
-    }
-
-    @Transactional
-    public void completeDelivery(CompleteDeliveryCommand completeDeliveryCommand) {
-        Delivery delivery = findDeliveryByDeliveryId(completeDeliveryCommand.deliveryId());
-        delivery.completeDelivery();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/CompleteDeliveryCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/CompleteDeliveryCommand.java
@@ -1,8 +1,8 @@
 package com.prgrms.nabmart.domain.delivery.service.request;
 
-public record CompleteDeliveryCommand(Long deliveryId) {
+public record CompleteDeliveryCommand(Long deliveryId, Long riderId) {
 
-    public static CompleteDeliveryCommand from(final Long deliveryId) {
-        return new CompleteDeliveryCommand(deliveryId);
+    public static CompleteDeliveryCommand of(final Long deliveryId, Long riderId) {
+        return new CompleteDeliveryCommand(deliveryId, riderId);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/CompleteDeliveryCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/CompleteDeliveryCommand.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.service.request;
 
 public record CompleteDeliveryCommand(Long deliveryId, Long riderId) {
 
-    public static CompleteDeliveryCommand of(final Long deliveryId, Long riderId) {
+    public static CompleteDeliveryCommand of(final Long deliveryId, final Long riderId) {
         return new CompleteDeliveryCommand(deliveryId, riderId);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/StartDeliveryCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/request/StartDeliveryCommand.java
@@ -2,11 +2,13 @@ package com.prgrms.nabmart.domain.delivery.service.request;
 
 public record StartDeliveryCommand(
     Long deliveryId,
-    int deliveryEstimateMinutes) {
+    int deliveryEstimateMinutes,
+    Long riderId) {
 
     public static StartDeliveryCommand of(
         final Long deliveryId,
-        final Integer deliveryEstimateMinutes) {
-        return new StartDeliveryCommand(deliveryId, deliveryEstimateMinutes);
+        final Integer deliveryEstimateMinutes,
+        final Long riderId) {
+        return new StartDeliveryCommand(deliveryId, deliveryEstimateMinutes, riderId);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
@@ -8,8 +8,6 @@ public record FindDeliveryDetailResponse(
     Long deliveryId,
     DeliveryStatus deliveryStatus,
     LocalDateTime arrivedAt,
-    String address,
-    int deliveryFee,
     Long orderId,
     String name,
     int price) {
@@ -19,8 +17,6 @@ public record FindDeliveryDetailResponse(
             delivery.getDeliveryId(),
             delivery.getDeliveryStatus(),
             delivery.getArrivedAt(),
-            delivery.getAddress(),
-            delivery.getDeliveryFee(),
             delivery.getOrder().getOrderId(),
             delivery.getOrder().getName(),
             delivery.getOrder().getPrice());

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
@@ -19,13 +19,11 @@ public record FindWaitingDeliveriesResponse(
             deliveryResponses.getTotalElements());
     }
 
-    public record FindWaitingDeliveryResponse(Long deliveryId, String address, int deliveryFee) {
+    public record FindWaitingDeliveryResponse(Long deliveryId) {
 
         public static FindWaitingDeliveryResponse from(final Delivery delivery) {
             return new FindWaitingDeliveryResponse(
-                delivery.getDeliveryId(),
-                delivery.getAddress(),
-                delivery.getDeliveryFee());
+                delivery.getDeliveryId());
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryTest.java
@@ -2,9 +2,7 @@ package com.prgrms.nabmart.domain.delivery;
 
 import static com.prgrms.nabmart.domain.order.support.OrderFixture.deliveringOrder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
@@ -30,28 +28,10 @@ class DeliveryTest {
             //when
             Delivery delivery = Delivery.builder()
                 .order(order)
-                .address(address)
                 .build();
 
             //then
-            assertThat(delivery.getAddress()).isEqualTo(address);
             assertThat(delivery.getOrder()).isEqualTo(order);
-        }
-
-        @Test
-        @DisplayName("예외: 주소 길이가 500자를 초과")
-        void throwExceptionWhenInvalidAddressLength() {
-            //given
-            String invalidAddress = "a".repeat(501);
-
-            //when
-            //then
-            assertThatThrownBy(() ->
-                Delivery.builder()
-                    .order(order)
-                    .address(invalidAddress)
-                    .build())
-                .isInstanceOf(InvalidDeliveryException.class);
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -63,8 +63,6 @@ class DeliveryControllerTest extends BaseControllerTest {
                         fieldWithPath("deliveryId").type(NUMBER).description("배달 ID"),
                         fieldWithPath("deliveryStatus").type(STRING).description("배달 ID"),
                         fieldWithPath("arrivedAt").type(STRING).description("도착 시간"),
-                        fieldWithPath("address").type(STRING).description("주소"),
-                        fieldWithPath("deliveryFee").type(NUMBER).description("배달비"),
                         fieldWithPath("orderId").type(NUMBER).description("주문 ID"),
                         fieldWithPath("name").type(STRING).description("주문 이름"),
                         fieldWithPath("price").type(NUMBER).description("주문 가격")
@@ -168,8 +166,6 @@ class DeliveryControllerTest extends BaseControllerTest {
                     responseFields(
                         fieldWithPath("deliveries").type(ARRAY).description("배달 목록"),
                         fieldWithPath("deliveries[].deliveryId").type(NUMBER).description("배달 ID"),
-                        fieldWithPath("deliveries[].address").type(STRING).description("배달 주소"),
-                        fieldWithPath("deliveries[].deliveryFee").type(NUMBER).description("배달 비"),
                         fieldWithPath("page").type(NUMBER).description("페이지"),
                         fieldWithPath("totalElements").type(NUMBER).description("사이즈")
                     )

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -122,11 +122,15 @@ class DeliveryControllerTest extends BaseControllerTest {
 
             //when
             ResultActions resultActions = mockMvc
-                .perform(patch("/api/v1/deliveries/complete/{deliveryId}", deliveryId));
+                .perform(patch("/api/v1/deliveries/complete/{deliveryId}", deliveryId)
+                    .header(AUTHORIZATION, accessToken));
 
             //then
             resultActions.andExpect(status().isNoContent())
                 .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName(AUTHORIZATION).description("액세스 토큰")
+                    ),
                     pathParameters(
                         parameterWithName("deliveryId").description("배달 ID")
                     )

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -89,12 +89,16 @@ class DeliveryControllerTest extends BaseControllerTest {
             //when
             ResultActions resultActions
                 = mockMvc.perform(patch("/api/v1/deliveries/pickup/{deliveryId}", deliveryId)
+                .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(startDeliveryRequest)));
 
             //then
             resultActions.andExpect(status().isNoContent())
                 .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName(AUTHORIZATION).description("액세스 토큰")
+                    ),
                     pathParameters(
                         parameterWithName("deliveryId").description("배달 ID")
                     ),

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -90,8 +90,6 @@ class DeliveryServiceTest {
             //then
             assertThat(findDeliveryDetailResponse.deliveryStatus())
                 .isEqualTo(delivery.getDeliveryStatus());
-            assertThat(findDeliveryDetailResponse.address())
-                .isEqualTo(delivery.getAddress());
             assertThat(findDeliveryDetailResponse.arrivedAt())
                 .isEqualTo(delivery.getArrivedAt());
             assertThat(findDeliveryDetailResponse.name())

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -2,6 +2,7 @@ package com.prgrms.nabmart.domain.delivery.support;
 
 import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.DeliveryStatus;
+import com.prgrms.nabmart.domain.delivery.Rider;
 import com.prgrms.nabmart.domain.delivery.service.request.FindDeliveryCommand;
 import com.prgrms.nabmart.domain.delivery.service.response.FindWaitingDeliveriesResponse;
 import com.prgrms.nabmart.domain.delivery.service.response.FindWaitingDeliveriesResponse.FindWaitingDeliveryResponse;
@@ -26,6 +27,9 @@ public final class DeliveryFixture {
     private static final int ORDER_PRICE = 1000;
     private static final int ESTIMATE_MINUTES = 20;
     private static final int PAGE = 0;
+    private static final String RIDER_USERNAME = "username";
+    private static final String RIDER_PASSWORD = "password123";
+    private static final String RIDER_ADDRESS = "address";
 
     public static Delivery delivery(Order order) {
         return Delivery.builder()
@@ -33,6 +37,12 @@ public final class DeliveryFixture {
             .address(ADDRESS)
             .deliveryFee(DELIVERY_FEE)
             .build();
+    }
+
+    public static Delivery acceptedDelivery(Order order, Rider rider) {
+        Delivery delivery = delivery(order);
+        delivery.acceptDelivery(rider);
+        return delivery;
     }
 
     public static FindDeliveryCommand findDeliveryCommand() {
@@ -56,5 +66,9 @@ public final class DeliveryFixture {
         FindWaitingDeliveryResponse findWaitingDeliveryResponse
             = new FindWaitingDeliveryResponse(DELIVERY_ID, ADDRESS, DELIVERY_FEE);
         return new FindWaitingDeliveriesResponse(List.of(findWaitingDeliveryResponse), PAGE, 1);
+    }
+
+    public static Rider rider() {
+        return new Rider(RIDER_USERNAME, RIDER_PASSWORD, RIDER_ADDRESS);
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -34,8 +34,6 @@ public final class DeliveryFixture {
     public static Delivery delivery(Order order) {
         return Delivery.builder()
             .order(order)
-            .address(ADDRESS)
-            .deliveryFee(DELIVERY_FEE)
             .build();
     }
 
@@ -54,8 +52,6 @@ public final class DeliveryFixture {
             DELIVERY_ID,
             DELIVERY_STATUS,
             ARRIVED_AT,
-            ADDRESS,
-            DELIVERY_FEE,
             ORDER_ID,
             ORDER_NAME,
             ORDER_PRICE
@@ -64,7 +60,7 @@ public final class DeliveryFixture {
 
     public static FindWaitingDeliveriesResponse findDeliveriesResponse() {
         FindWaitingDeliveryResponse findWaitingDeliveryResponse
-            = new FindWaitingDeliveryResponse(DELIVERY_ID, ADDRESS, DELIVERY_FEE);
+            = new FindWaitingDeliveryResponse(DELIVERY_ID);
         return new FindWaitingDeliveriesResponse(List.of(findWaitingDeliveryResponse), PAGE, 1);
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 배달 픽업, 배달 완료 API에 라이더 추가를 반영하였습니다.
- `Order`에 배달비, 주소 필드를 추가함에 따라 `Delivery`에서 해당 필드를 우선 제거하였습니다. 추후 반정규화를 통해서 추가를 고려중입니다.


### 📝 작업 요약
- 배달 도메인에 라이더 추가를 반영
- `Order` 엔티티, `address`, `deliveryFee` 인스턴스 변수 제거


### 💡 관련 이슈
- [NAYB-124](https://naybmart.atlassian.net/browse/NAYB-124)



[NAYB-124]: https://naybmart.atlassian.net/browse/NAYB-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ