### PR TITLE
[NAYB-133] feat: 두 명의 라이더가 동일한 주문에 동시에 배차요청을 하면 다른 라이더는 실패한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### VS Code ###
 .vscode/
 .DS_Store
+
+### QueryDSL ###
+/src/main/generated

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -44,6 +45,9 @@ public class Delivery extends BaseTimeEntity {
 
     @Column
     private LocalDateTime arrivedAt;
+
+    @Version
+    private Long version;
 
     @Builder
     public Delivery(final Order order) {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -7,6 +7,7 @@ import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.global.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,11 +33,11 @@ public class Delivery extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long deliveryId;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "orderId", nullable = false)
     private Order order;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "riderId")
     private Rider rider;
 

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/AlreadyAssignedDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/AlreadyAssignedDeliveryException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.delivery.exception;
 
 public class AlreadyAssignedDeliveryException extends DeliveryException {
 
-    public AlreadyAssignedDeliveryException(String message) {
+    public AlreadyAssignedDeliveryException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/exception/AlreadyAssignedDeliveryException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/exception/AlreadyAssignedDeliveryException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.delivery.exception;
+
+public class AlreadyAssignedDeliveryException extends DeliveryException {
+
+    public AlreadyAssignedDeliveryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -3,11 +3,13 @@ package com.prgrms.nabmart.domain.delivery.repository;
 import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.DeliveryStatus;
 import com.prgrms.nabmart.domain.delivery.Rider;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,4 +36,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
         @Param("rider") Rider rider,
         @Param("statuses") List<DeliveryStatus> deliveryStatuses,
         Pageable pageable);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select d from Delivery d where d.deliveryId = :deliveryId")
+    Optional<Delivery> findByIdOptimistic(@Param("deliveryId") Long deliveryId);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
@@ -49,8 +49,14 @@ public class DeliveryService {
     @Transactional
     public void acceptDelivery(AcceptDeliveryCommand acceptDeliveryCommand) {
         Rider rider = findRiderByRiderId(acceptDeliveryCommand.riderId());
-        Delivery delivery = findDeliveryByDeliveryId(acceptDeliveryCommand.deliveryId());
+        Delivery delivery = findDeliveryByDeliveryIdOptimistic(acceptDeliveryCommand);
         delivery.assignRider(rider);
+    }
+
+    private Delivery findDeliveryByDeliveryIdOptimistic(
+        AcceptDeliveryCommand acceptDeliveryCommand) {
+        return deliveryRepository.findByIdOptimistic(acceptDeliveryCommand.deliveryId())
+            .orElseThrow(() -> new NotFoundDeliveryException("존재하지 않는 배달입니다."));
     }
 
     @Transactional

--- a/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
@@ -1,0 +1,95 @@
+package com.prgrms.nabmart.base;
+
+import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
+import com.prgrms.nabmart.domain.cart.repository.CartRepository;
+import com.prgrms.nabmart.domain.category.repository.MainCategoryRepository;
+import com.prgrms.nabmart.domain.category.repository.SubCategoryRepository;
+import com.prgrms.nabmart.domain.coupon.repository.CouponRepository;
+import com.prgrms.nabmart.domain.coupon.repository.UserCouponRepository;
+import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
+import com.prgrms.nabmart.domain.event.repository.EventItemRepository;
+import com.prgrms.nabmart.domain.event.repository.EventRepository;
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
+import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
+import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
+import com.prgrms.nabmart.domain.order.repository.OrderRepository;
+import com.prgrms.nabmart.domain.payment.repository.PaymentRepository;
+import com.prgrms.nabmart.domain.review.repository.ReviewRepository;
+import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class IntegrationTest {
+
+    @Autowired
+    protected CartItemRepository cartItemRepository;
+
+    @Autowired
+    protected CartRepository cartRepository;
+
+    @Autowired
+    protected MainCategoryRepository mainCategoryRepository;
+
+    @Autowired
+    protected SubCategoryRepository subCategoryRepository;
+
+    @Autowired
+    protected CouponRepository couponRepository;
+
+    @Autowired
+    protected UserCouponRepository userCouponRepository;
+
+    @Autowired
+    protected DeliveryRepository deliveryRepository;
+
+    @Autowired
+    protected RiderRepository riderRepository;
+
+    @Autowired
+    protected EventItemRepository eventItemRepository;
+
+    @Autowired
+    protected EventRepository eventRepository;
+
+    @Autowired
+    protected ItemRepository itemRepository;
+
+    @Autowired
+    protected LikeItemRepository likeItemRepository;
+
+    @Autowired
+    protected OrderItemRepository orderItemRepository;
+
+    @Autowired
+    protected OrderRepository orderRepository;
+
+    @Autowired
+    protected PaymentRepository paymentRepository;
+
+    @Autowired
+    protected ReviewRepository reviewRepository;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @BeforeAll
+    static void beforeAll() {
+        Properties properties = System.getProperties();
+        properties.setProperty("ISSUER", "issuer");
+        properties.setProperty("CLIENT_SECRET", "clientSecret");
+        properties.setProperty("NAVER_CLIENT_ID", "naverClientId");
+        properties.setProperty("NAVER_CLIENT_SECRET", "naverClientSecret");
+        properties.setProperty("KAKAO_CLIENT_ID", "kakaoClientId");
+        properties.setProperty("KAKAO_CLIENT_SECRET", "kakaoClientSecret");
+        properties.setProperty("REDIRECT_URI",
+            "http://localhost:8080/login/oauth2/code/{registrationId}");
+        properties.setProperty("EXPIRY_SECONDS", "60");
+        properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
+        properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
+        properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.prgrms.nabmart.domain.delivery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prgrms.nabmart.base.IntegrationTest;
+import com.prgrms.nabmart.domain.category.MainCategory;
+import com.prgrms.nabmart.domain.category.SubCategory;
+import com.prgrms.nabmart.domain.category.fixture.CategoryFixture;
+import com.prgrms.nabmart.domain.delivery.service.DeliveryService;
+import com.prgrms.nabmart.domain.delivery.service.request.AcceptDeliveryCommand;
+import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.support.ItemFixture;
+import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.order.OrderItem;
+import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.domain.user.support.UserFixture;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DeliveryIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    DeliveryService deliveryService;
+
+    @Nested
+    @DisplayName("acceptDelivery 메서드 실행 시")
+    class AcceptDeliveryTest {
+
+        ExecutorService service;
+        CountDownLatch latch;
+
+        User user = UserFixture.user();
+        MainCategory mainCategory = CategoryFixture.mainCategory();
+        SubCategory subCategory = CategoryFixture.subCategory(mainCategory);
+        Item item = ItemFixture.item(mainCategory, subCategory);
+        OrderItem orderItem = new OrderItem(item, 5);
+        Order order = new Order(user, List.of(orderItem));
+
+        @BeforeEach
+        void setUpConcurrent() {
+            service = Executors.newFixedThreadPool(4);
+            latch = new CountDownLatch(4);
+        }
+
+        @BeforeEach
+        void setUpData() {
+            userRepository.save(user);
+            mainCategoryRepository.save(mainCategory);
+            subCategoryRepository.save(subCategory);
+            itemRepository.save(item);
+            orderRepository.save(order);
+        }
+
+
+        List<Rider> createAndSaveRiders(int end) {
+            List<Rider> riders = IntStream.range(0, end)
+                .mapToObj(i -> Rider.builder()
+                    .username("username" + i)
+                    .password("password" + i)
+                    .address("address")
+                    .build())
+                .toList();
+            riderRepository.saveAll(riders);
+            return riders;
+        }
+
+        private Delivery createAndSaveDelivery() {
+            Delivery delivery = new Delivery(order);
+            deliveryRepository.save(delivery);
+            return delivery;
+        }
+
+        @Test
+        @DisplayName("성공: 여러 명의 라이더 중 한 명만 성공")
+        void success() throws InterruptedException {
+            //given
+            Delivery targetDelivery = createAndSaveDelivery();
+            List<Rider> riders = createAndSaveRiders(4);
+
+            //when
+            for (int i = 0; i < 4; i++) {
+                Rider rider = riders.get(i);
+                service.execute(() -> {
+                    AcceptDeliveryCommand command = AcceptDeliveryCommand.of(
+                        targetDelivery.getDeliveryId(), rider.getRiderId());
+                    try {
+                        deliveryService.acceptDelivery(command);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+
+            //then
+            Delivery findDelivery
+                = deliveryRepository.findById(targetDelivery.getDeliveryId()).get();
+            assertThat(findDelivery.getVersion()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -2,6 +2,7 @@ package com.prgrms.nabmart.domain.delivery.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.prgrms.nabmart.base.BaseControllerTest;
 import com.prgrms.nabmart.domain.delivery.DeliveryStatus;
 import com.prgrms.nabmart.domain.delivery.controller.request.StartDeliveryRequest;
+import com.prgrms.nabmart.domain.delivery.exception.AlreadyAssignedDeliveryException;
 import com.prgrms.nabmart.domain.delivery.service.response.FindDeliveryDetailResponse;
 import com.prgrms.nabmart.domain.delivery.service.response.FindRiderDeliveriesResponse;
 import com.prgrms.nabmart.domain.delivery.service.response.FindRiderDeliveriesResponse.FindRiderDeliveryResponse;
@@ -101,6 +103,22 @@ class DeliveryControllerTest extends BaseControllerTest {
                         parameterWithName("deliveryId").description("배달 ID")
                     )
                 ));
+        }
+
+        @Test
+        @DisplayName("예외: 이미 배정된 배달")
+        void exceptionWhenAlreadyAssignedDelivery() throws Exception {
+            //given
+            doThrow(AlreadyAssignedDeliveryException.class).when(deliveryService)
+                .acceptDelivery(any());
+
+            //when
+            ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/deliveries/{deliveryId}/accept", 1L)
+                    .header(AUTHORIZATION, accessToken));
+
+            //then
+            resultActions.andExpect(status().isConflict());
         }
     }
 

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -363,7 +363,8 @@ class DeliveryServiceTest {
         void success() {
             //given
             given(riderRepository.findById(any())).willReturn(Optional.ofNullable(rider));
-            given(deliveryRepository.findById(any())).willReturn(Optional.ofNullable(delivery));
+            given(deliveryRepository.findByIdOptimistic(any()))
+                .willReturn(Optional.ofNullable(delivery));
 
             //when
             deliveryService.acceptDelivery(acceptDeliveryCommand);
@@ -389,7 +390,7 @@ class DeliveryServiceTest {
         void throwExceptionWhenNotFoundDelivery() {
             //given
             given(riderRepository.findById(any())).willReturn(Optional.ofNullable(rider));
-            given(deliveryRepository.findById(any())).willReturn(Optional.empty());
+            given(deliveryRepository.findByIdOptimistic(any())).willReturn(Optional.empty());
 
             //when
             //then


### PR DESCRIPTION
### ⛏ 작업 사항
- 여러 명의 라이더가 하나의 배달에 대해 배차 요청을 할 경우 갱신 손실이 발생하지 않도록 작업하였습니다.
- 배차 요청이 실패할 경우 409 CONFLICT 로 응답합니다.


### 📝 작업 요약
- 낙관적 락을 위한 `Delivery` `version` 필드 추가
- `Delivery` 조회시 OPTIMISTIC 락으로 조회하는 쿼리 추가
- 관련된 메서드 수정 및 동시성 테스트 추가


### 💡 관련 이슈
-[NAYB-133](https://naybmart.atlassian.net/browse/NAYB-133)


[NAYB-133]: https://naybmart.atlassian.net/browse/NAYB-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ