### PR TITLE
[NAYB-134] feat: 인증되지 않은 사용자 요청 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthExceptionHandler.java
@@ -15,8 +15,8 @@ public class AuthExceptionHandler {
             .body(ErrorTemplate.of(ex.getMessage()));
     }
 
-    @ExceptionHandler(OAuthUnlinkFailureException.class)
-    public ResponseEntity<ErrorTemplate> oAuthUnlinkFailureExHandle(OAuthUnlinkFailureException ex) {
+    @ExceptionHandler({OAuthUnlinkFailureException.class, UnAuthenticationException.class})
+    public ResponseEntity<ErrorTemplate> authenticationFailExHand(AuthException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(ErrorTemplate.of(ex.getMessage()));
     }

--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/UnAuthenticationException.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/UnAuthenticationException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.global.auth.exception;
+
+public class UnAuthenticationException extends AuthException {
+
+    public UnAuthenticationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
@@ -1,7 +1,9 @@
 package com.prgrms.nabmart.global.auth.resolver;
 
 import com.prgrms.nabmart.global.auth.LoginUser;
+import com.prgrms.nabmart.global.auth.exception.UnAuthenticationException;
 import com.prgrms.nabmart.global.auth.jwt.dto.JwtAuthentication;
+import java.util.Objects;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -26,6 +28,9 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         NativeWebRequest webRequest,
         WebDataBinderFactory binderFactory) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(Objects.isNull(authentication)) {
+            throw new UnAuthenticationException("인증되지 않은 요청입니다.");
+        }
         JwtAuthentication jwtAuthentication = (JwtAuthentication) authentication.getPrincipal();
         return jwtAuthentication.userId();
     }

--- a/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolver.java
@@ -28,10 +28,14 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         NativeWebRequest webRequest,
         WebDataBinderFactory binderFactory) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        checkAuthenticated(authentication);
+        JwtAuthentication jwtAuthentication = (JwtAuthentication) authentication.getPrincipal();
+        return jwtAuthentication.userId();
+    }
+
+    private void checkAuthenticated(Authentication authentication) {
         if(Objects.isNull(authentication)) {
             throw new UnAuthenticationException("인증되지 않은 요청입니다.");
         }
-        JwtAuthentication jwtAuthentication = (JwtAuthentication) authentication.getPrincipal();
-        return jwtAuthentication.userId();
     }
 }

--- a/src/test/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/resolver/LoginUserArgumentResolverTest.java
@@ -3,21 +3,27 @@ package com.prgrms.nabmart.global.auth.resolver;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.prgrms.nabmart.domain.user.service.response.RegisterUserResponse;
 import com.prgrms.nabmart.global.auth.LoginUser;
+import com.prgrms.nabmart.global.auth.exception.UnAuthenticationException;
 import com.prgrms.nabmart.global.auth.jwt.TokenProvider;
 import com.prgrms.nabmart.global.auth.jwt.dto.CreateTokenCommand;
 import com.prgrms.nabmart.global.auth.support.AuthFixture;
+import com.prgrms.nabmart.global.util.ErrorTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,6 +35,12 @@ class LoginUserArgumentResolverTest {
         @GetMapping("/resolvers")
         public Long resolvers(@LoginUser Long userId) {
             return userId;
+        }
+
+        @ExceptionHandler(UnAuthenticationException.class)
+        public ResponseEntity<ErrorTemplate> ex(UnAuthenticationException ex) {
+            ErrorTemplate errorTemplate = ErrorTemplate.of(ex.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorTemplate);
         }
     }
 
@@ -43,9 +55,6 @@ class LoginUserArgumentResolverTest {
             .build();
         tokenProvider = AuthFixture.tokenProvider();
         userResponse = AuthFixture.registerUserResponse();
-
-        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     @Nested
@@ -56,6 +65,9 @@ class LoginUserArgumentResolverTest {
         @DisplayName("성공: authentication 객체에서 userId를 추출하여 인자로 전달")
         void success() throws Exception {
             //given
+            Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
             CreateTokenCommand createTokenCommand = CreateTokenCommand.from(userResponse);
             String token = tokenProvider.createToken(createTokenCommand);
 
@@ -66,6 +78,20 @@ class LoginUserArgumentResolverTest {
             //then
             resultActions.andDo(print())
                 .andExpect(jsonPath("$").isNumber());
+        }
+
+        @Test
+        @DisplayName("예외: authentication 객체가 존재하지 않음")
+        void throwExceptionWhenAuthenticationIsNull() throws Exception {
+            //given
+            SecurityContextHolder.getContext().setAuthentication(null);
+
+            //when
+            ResultActions resultActions = mvc.perform(get("/resolvers"));
+
+            //then
+            resultActions.andDo(print())
+                .andExpect(status().isUnauthorized());
         }
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 인증이 필요한 요청에 대해 토큰이 포함되지 않은 요청이 들어올 경우 커스텀 예외를 던지도록 하였습니다.
- 추후 시큐리티 설정을 통해 api를 걸러낼 예정입니다. 현재 추가한 부분은 시큐리티 필터가 인증이 필요한 요청을 잡아내지 못하고 `LoginUserArgumentResolver`까지 도달할 경우 예외가 터집니다.
- 이 경우 401 UNAUTHORIZED 응답을 반환합니다.


### 📝 작업 요약
- `LoginUserArgumentResolver`에 도달한 요청에 `Authentication` 객체가 존재하지 않는 경우 `UnAuthenticationException`을 던지도록 추가
- `UnAuthenticationException`을 잡는 예외 핸들러 추가


### 💡 관련 이슈
- [NAYB-134](https://naybmart.atlassian.net/browse/NAYB-134)


[NAYB-134]: https://naybmart.atlassian.net/browse/NAYB-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ