### PR TITLE
[NAYB-150] feat: 배달 목록 조회 시 응답 데이터  추가

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/deliveries")
+@RequestMapping("/api/v1")
 public class DeliveryController {
 
     private final DeliveryService deliveryService;
@@ -47,7 +47,7 @@ public class DeliveryController {
         return ResponseEntity.ok(findDeliveryDetailResponse);
     }
 
-    @PatchMapping("/{deliveryId}/accept")
+    @PatchMapping("/deliveries/{deliveryId}/accept")
     public ResponseEntity<Void> acceptDelivery(
         @PathVariable final Long deliveryId,
         @LoginUser final Long riderId) {
@@ -64,7 +64,7 @@ public class DeliveryController {
         }
     }
 
-    @PatchMapping("/{deliveryId}/pickup")
+    @PatchMapping("/deliveries/{deliveryId}/pickup")
     public ResponseEntity<Void> startDelivery(
         @PathVariable final Long deliveryId,
         @RequestBody @Valid StartDeliveryRequest startDeliveryRequest,
@@ -77,7 +77,7 @@ public class DeliveryController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/{deliveryId}/complete")
+    @PatchMapping("/deliveries/{deliveryId}/complete")
     public ResponseEntity<Void> completeDelivery(
         @PathVariable final Long deliveryId,
         @LoginUser final Long riderId) {
@@ -87,7 +87,7 @@ public class DeliveryController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/waiting")
+    @GetMapping("/deliveries/waiting")
     public ResponseEntity<FindWaitingDeliveriesResponse> findWaitingDeliveries(
         final Pageable pageable) {
         FindWaitingDeliveriesCommand findWaitingDeliveriesCommand
@@ -97,7 +97,7 @@ public class DeliveryController {
         return ResponseEntity.ok(findWaitingDeliveriesResponse);
     }
 
-    @GetMapping
+    @GetMapping("/deliveries")
     public ResponseEntity<FindRiderDeliveriesResponse> findRiderDeliveries(
         FindRiderDeliveriesRequest findRiderDeliveriesRequest,
         final Pageable pageable,

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -37,7 +37,7 @@ public class DeliveryController {
 
     private final DeliveryService deliveryService;
 
-    @GetMapping("/{orderId}")
+    @GetMapping("/orders/{orderId}/deliveries")
     public ResponseEntity<FindDeliveryDetailResponse> findDelivery(
         @PathVariable final Long orderId,
         @LoginUser final Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
@@ -7,18 +7,22 @@ import java.time.LocalDateTime;
 public record FindDeliveryDetailResponse(
     Long deliveryId,
     DeliveryStatus deliveryStatus,
+    LocalDateTime createdAt,
     LocalDateTime arrivedAt,
     Long orderId,
-    String name,
-    int price) {
+    String orderName,
+    int orderPrice,
+    String riderRequest) {
 
     public static FindDeliveryDetailResponse from(final Delivery delivery) {
         return new FindDeliveryDetailResponse(
             delivery.getDeliveryId(),
             delivery.getDeliveryStatus(),
+            delivery.getCreatedAt(),
             delivery.getArrivedAt(),
             delivery.getOrder().getOrderId(),
             delivery.getOrder().getName(),
-            delivery.getOrder().getPrice());
+            delivery.getOrder().getPrice(),
+            delivery.getOrder().getRiderRequest());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
@@ -27,7 +27,10 @@ public record FindRiderDeliveriesResponse(
         Long deliveryId,
         DeliveryStatus deliveryStatus,
         LocalDateTime arrivedAt,
+        LocalDateTime createdAt,
         String address,
+        int orderPrice,
+        String riderRequest,
         int deliveryFee) {
 
         public static FindRiderDeliveryResponse from(final Delivery delivery) {
@@ -35,7 +38,10 @@ public record FindRiderDeliveriesResponse(
                 delivery.getDeliveryId(),
                 delivery.getDeliveryStatus(),
                 delivery.getArrivedAt(),
+                delivery.getCreatedAt(),
                 delivery.getOrder().getAddress(),
+                delivery.getOrder().getPrice(),
+                delivery.getOrder().getRiderRequest(),
                 delivery.getOrder().getDeliveryFee());
         }
     }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
@@ -1,6 +1,7 @@
 package com.prgrms.nabmart.domain.delivery.service.response;
 
 import com.prgrms.nabmart.domain.delivery.Delivery;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
@@ -19,11 +20,20 @@ public record FindWaitingDeliveriesResponse(
             deliveryResponses.getTotalElements());
     }
 
-    public record FindWaitingDeliveryResponse(Long deliveryId) {
+    public record FindWaitingDeliveryResponse(
+        Long deliveryId,
+        LocalDateTime arrivedAt,
+        LocalDateTime createdAt,
+        String address,
+        int deliveryFee) {
 
         public static FindWaitingDeliveryResponse from(final Delivery delivery) {
             return new FindWaitingDeliveryResponse(
-                delivery.getDeliveryId());
+                delivery.getDeliveryId(),
+                delivery.getArrivedAt(),
+                delivery.getCreatedAt(),
+                delivery.getOrder().getAddress(),
+                delivery.getOrder().getDeliveryFee());
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
@@ -91,5 +91,7 @@ public abstract class IntegrationTest {
         properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
         properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
         properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+        properties.setProperty("REDIS_HOST", "localhost");
+        properties.setProperty("REDIS_PORT", "6379");
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -68,11 +68,13 @@ class DeliveryControllerTest extends BaseControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("deliveryId").type(NUMBER).description("배달 ID"),
-                        fieldWithPath("deliveryStatus").type(STRING).description("배달 ID"),
-                        fieldWithPath("arrivedAt").type(STRING).description("도착 시간"),
+                        fieldWithPath("deliveryStatus").type(STRING).description("배달 상태"),
+                        fieldWithPath("createdAt").type(STRING).description("배달 생성 시각"),
+                        fieldWithPath("arrivedAt").type(STRING).description("배달 완료 예정 시각"),
                         fieldWithPath("orderId").type(NUMBER).description("주문 ID"),
-                        fieldWithPath("name").type(STRING).description("주문 이름"),
-                        fieldWithPath("price").type(NUMBER).description("주문 가격")
+                        fieldWithPath("orderName").type(STRING).description("주문 이름"),
+                        fieldWithPath("orderPrice").type(NUMBER).description("주문 가격"),
+                        fieldWithPath("riderRequest").type(STRING).description("배달원 요청 사항")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -216,7 +216,16 @@ class DeliveryControllerTest extends BaseControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("deliveries").type(ARRAY).description("배달 목록"),
-                        fieldWithPath("deliveries[].deliveryId").type(NUMBER).description("배달 ID"),
+                        fieldWithPath("deliveries[].deliveryId").type(NUMBER)
+                            .description("배달 ID"),
+                        fieldWithPath("deliveries[].arrivedAt").type(STRING)
+                            .description("배달 완료 예정 시간"),
+                        fieldWithPath("deliveries[].createdAt").type(STRING)
+                            .description("배달 접수 시간"),
+                        fieldWithPath("deliveries[].address").type(STRING)
+                            .description("배달 목적지"),
+                        fieldWithPath("deliveries[].deliveryFee").type(NUMBER)
+                            .description("배달비"),
                         fieldWithPath("page").type(NUMBER).description("페이지"),
                         fieldWithPath("totalElements").type(NUMBER).description("사이즈")
                     )

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -53,7 +53,7 @@ class DeliveryControllerTest extends BaseControllerTest {
 
             //when
             ResultActions resultActions = mockMvc
-                .perform(get("/api/v1/deliveries/{orderId}", orderId)
+                .perform(get("/api/v1/orders/{orderId}/deliveries", orderId)
                     .header(AUTHORIZATION, accessToken)
                     .accept(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -246,7 +246,10 @@ class DeliveryControllerTest extends BaseControllerTest {
                 1L,
                 deliveryStatus,
                 LocalDateTime.now().plusMinutes(20),
+                LocalDateTime.now(),
                 "address",
+                15000,
+                "문 앞에 두고 벨 눌러주세요.",
                 3000
             );
             FindRiderDeliveriesResponse findRiderDeliveriesResponse
@@ -275,6 +278,27 @@ class DeliveryControllerTest extends BaseControllerTest {
                         parameterWithName("deliveryStatuses").description("배달 상태 목록"),
                         parameterWithName("page").description("페이지"),
                         parameterWithName("size").description("페이지 사이즈")
+                    ),
+                    responseFields(
+                        fieldWithPath("deliveries").type(ARRAY).description("배달 목록"),
+                        fieldWithPath("deliveries[].deliveryId").type(NUMBER)
+                            .description("배달 ID"),
+                        fieldWithPath("deliveries[].deliveryStatus").type(STRING)
+                            .description("배달 상태"),
+                        fieldWithPath("deliveries[].arrivedAt").type(STRING)
+                            .description("배달 완료 예정 시각"),
+                        fieldWithPath("deliveries[].createdAt").type(STRING)
+                            .description("배달 생성 시각"),
+                        fieldWithPath("deliveries[].address").type(STRING)
+                            .description("배달 목적지"),
+                        fieldWithPath("deliveries[].orderPrice").type(NUMBER)
+                            .description("주문 가격"),
+                        fieldWithPath("deliveries[].riderRequest").type(STRING)
+                            .description("배달원 요청 사항"),
+                        fieldWithPath("deliveries[].deliveryFee").type(NUMBER)
+                            .description("배달비"),
+                        fieldWithPath("page").type(NUMBER).description("페이지"),
+                        fieldWithPath("totalElements").type(NUMBER).description("총 요소 갯수")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -95,11 +95,15 @@ class DeliveryServiceTest {
             assertThat(findDeliveryDetailResponse.deliveryStatus())
                 .isEqualTo(delivery.getDeliveryStatus());
             assertThat(findDeliveryDetailResponse.arrivedAt())
+                .isEqualTo(delivery.getCreatedAt());
+            assertThat(findDeliveryDetailResponse.arrivedAt())
                 .isEqualTo(delivery.getArrivedAt());
-            assertThat(findDeliveryDetailResponse.name())
+            assertThat(findDeliveryDetailResponse.orderName())
                 .isEqualTo(delivery.getOrder().getName());
-            assertThat(findDeliveryDetailResponse.price())
+            assertThat(findDeliveryDetailResponse.orderPrice())
                 .isEqualTo(delivery.getOrder().getPrice());
+            assertThat(findDeliveryDetailResponse.riderRequest())
+                .isEqualTo(delivery.getOrder().getRiderRequest());
         }
 
         @Test

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -53,10 +53,11 @@ public final class DeliveryFixture {
             DELIVERY_ID,
             DELIVERY_STATUS,
             NOW,
+            NOW,
             ORDER_ID,
             ORDER_NAME,
-            ORDER_PRICE
-        );
+            ORDER_PRICE,
+            RIDER_REQUEST);
     }
 
     public static FindWaitingDeliveriesResponse findDeliveriesResponse() {

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -19,12 +19,13 @@ public final class DeliveryFixture {
     private static final Long DELIVERY_ID = 1L;
     private static final String ADDRESS = "주소지";
     private static final int DELIVERY_FEE = 3000;
-    private static final LocalDateTime ARRIVED_AT = LocalDateTime.now();
+    private static final LocalDateTime NOW = LocalDateTime.now();
     private static final DeliveryStatus DELIVERY_STATUS = DeliveryStatus.ACCEPTING_ORDER;
     private static final Long USER_ID = 1L;
     private static final Long ORDER_ID = 1L;
     private static final String ORDER_NAME = "비비고 왕교자 외 2개";
     private static final int ORDER_PRICE = 1000;
+    private static final String RIDER_REQUEST = "문 앞에 두고 벨 눌러주세요.";
     private static final int ESTIMATE_MINUTES = 20;
     private static final int PAGE = 0;
     private static final String RIDER_USERNAME = "username";
@@ -51,7 +52,7 @@ public final class DeliveryFixture {
         return new FindDeliveryDetailResponse(
             DELIVERY_ID,
             DELIVERY_STATUS,
-            ARRIVED_AT,
+            NOW,
             ORDER_ID,
             ORDER_NAME,
             ORDER_PRICE
@@ -60,7 +61,7 @@ public final class DeliveryFixture {
 
     public static FindWaitingDeliveriesResponse findDeliveriesResponse() {
         FindWaitingDeliveryResponse findWaitingDeliveryResponse
-            = new FindWaitingDeliveryResponse(DELIVERY_ID);
+            = new FindWaitingDeliveryResponse(DELIVERY_ID, NOW, NOW, ADDRESS, DELIVERY_FEE);
         return new FindWaitingDeliveriesResponse(List.of(findWaitingDeliveryResponse), PAGE, 1);
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 배달 목록 조회 시 포함될 응답 데이터를 추가하였습니다.
- 구매자가 배달 현황 조회시 하용하는 api uri를 변경하였습니다.


### 📝 작업 요약
- `FindWaitingDeliveriesResponse`, `FindRiderDeliveriesResponse`, `FindDeliveryDetailResponse` 필드 수정
- 관련된 테스트 코드 수정


### 💡 관련 이슈
- [NAYB-150](https://naybmart.atlassian.net/browse/NAYB-150)


[NAYB-150]: https://naybmart.atlassian.net/browse/NAYB-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ