### PR TITLE
[NAYB-81] feat: 사용자와 연관된 데이터를 제거

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartItemRepository.java
@@ -2,12 +2,22 @@ package com.prgrms.nabmart.domain.cart.repository;
 
 import com.prgrms.nabmart.domain.cart.Cart;
 import com.prgrms.nabmart.domain.cart.CartItem;
+import com.prgrms.nabmart.domain.user.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
     List<CartItem> findAllByCartItemIdOrderByCreatedAt(Long cartItemId);
 
     List<CartItem> findAllByCartOrderByCreatedAt(Cart cart);
+
+    @Modifying
+    @Query("delete from CartItem ci"
+        + " where ci.cart ="
+        + " (select c from Cart c where c.user = :user)")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/cart/repository/CartRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUser(final User user);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/coupon/repository/UserCouponRepository.java
@@ -23,5 +23,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
         @Param("user") User user,
         @Param("isUsed") boolean isUsed,
         @Param("currentDate") LocalDate currentDate);
+
+    void deleteByUser(User findUser);
 }
 

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -28,6 +28,7 @@ public class Delivery extends BaseTimeEntity {
 
     private static final int ADDRESS_LENGTH = 500;
     private static final int ZERO = 0;
+    public static final String DELETED = "삭제됨";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -105,5 +106,6 @@ public class Delivery extends BaseTimeEntity {
 
     public void deleteAboutUser() {
         this.order = null;
+        this.address = DELETED;
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -50,10 +50,26 @@ public class Delivery extends BaseTimeEntity {
     @Version
     private Long version;
 
+    @Column
+    private String address;
+
+    @Column
+    private Integer orderPrice;
+
+    @Column
+    private String riderRequest;
+
+    @Column
+    private Integer deliveryFee;
+
     @Builder
     public Delivery(final Order order) {
         this.order = order;
         this.deliveryStatus = DeliveryStatus.ACCEPTING_ORDER;
+        this.address = order.getAddress();
+        this.orderPrice = order.getPrice();
+        this.riderRequest = order.getRiderRequest();
+        this.deliveryFee = order.getDeliveryFee();
     }
 
     public boolean isOwnByUser(final User user) {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -34,7 +34,7 @@ public class Delivery extends BaseTimeEntity {
     private Long deliveryId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "orderId", nullable = false)
+    @JoinColumn(name = "orderId")
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -85,5 +85,9 @@ public class Delivery extends BaseTimeEntity {
     public void completeDelivery() {
         this.arrivedAt = LocalDateTime.now();
         this.deliveryStatus = DeliveryStatus.DELIVERED;
+    }
+
+    public void deleteAboutUser() {
+        this.order = null;
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/deliveries")
+@RequestMapping("/api/v1")
 public class DeliveryController {
 
     private final DeliveryService deliveryService;
@@ -47,7 +47,7 @@ public class DeliveryController {
         return ResponseEntity.ok(findDeliveryDetailResponse);
     }
 
-    @PatchMapping("/{deliveryId}/accept")
+    @PatchMapping("/deliveries/{deliveryId}/accept")
     public ResponseEntity<Void> acceptDelivery(
         @PathVariable final Long deliveryId,
         @LoginUser final Long riderId) {
@@ -64,7 +64,7 @@ public class DeliveryController {
         }
     }
 
-    @PatchMapping("/{deliveryId}/pickup")
+    @PatchMapping("/deliveries/{deliveryId}/pickup")
     public ResponseEntity<Void> startDelivery(
         @PathVariable final Long deliveryId,
         @RequestBody @Valid StartDeliveryRequest startDeliveryRequest,
@@ -77,7 +77,7 @@ public class DeliveryController {
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/{deliveryId}/complete")
+    @PatchMapping("/deliveries/{deliveryId}/complete")
     public ResponseEntity<Void> completeDelivery(
         @PathVariable final Long deliveryId,
         @LoginUser final Long riderId) {
@@ -87,7 +87,7 @@ public class DeliveryController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/waiting")
+    @GetMapping("/deliveries/waiting")
     public ResponseEntity<FindWaitingDeliveriesResponse> findWaitingDeliveries(
         final Pageable pageable) {
         FindWaitingDeliveriesCommand findWaitingDeliveriesCommand
@@ -97,7 +97,7 @@ public class DeliveryController {
         return ResponseEntity.ok(findWaitingDeliveriesResponse);
     }
 
-    @GetMapping
+    @GetMapping("/deliveries")
     public ResponseEntity<FindRiderDeliveriesResponse> findRiderDeliveries(
         FindRiderDeliveriesRequest findRiderDeliveriesRequest,
         final Pageable pageable,

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryController.java
@@ -37,7 +37,7 @@ public class DeliveryController {
 
     private final DeliveryService deliveryService;
 
-    @GetMapping("/{orderId}")
+    @GetMapping("/orders/{orderId}/deliveries")
     public ResponseEntity<FindDeliveryDetailResponse> findDelivery(
         @PathVariable final Long orderId,
         @LoginUser final Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -47,4 +47,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     @Query("delete from Delivery d"
         + " where d.order = (select o from Order o where o.user = :user)")
     void deleteByUser(@Param("user") User user);
+
+    @Query("select d from Delivery d join d.order o where o.user = :user")
+    List<Delivery> findAllByUser(@Param("user") User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,11 +34,6 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     @Lock(LockModeType.OPTIMISTIC)
     @Query("select d from Delivery d where d.deliveryId = :deliveryId")
     Optional<Delivery> findByIdOptimistic(@Param("deliveryId") Long deliveryId);
-
-    @Modifying
-    @Query("delete from Delivery d"
-        + " where d.order = (select o from Order o where o.user = :user)")
-    void deleteByUser(@Param("user") User user);
 
     @Query("select d from Delivery d join d.order o where o.user = :user")
     List<Delivery> findAllByUser(@Param("user") User user);

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -3,6 +3,7 @@ package com.prgrms.nabmart.domain.delivery.repository;
 import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.DeliveryStatus;
 import com.prgrms.nabmart.domain.delivery.Rider;
+import com.prgrms.nabmart.domain.user.User;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +42,9 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     @Lock(LockModeType.OPTIMISTIC)
     @Query("select d from Delivery d where d.deliveryId = :deliveryId")
     Optional<Delivery> findByIdOptimistic(@Param("deliveryId") Long deliveryId);
+
+    @Modifying
+    @Query("delete from Delivery d"
+        + " where d.order = (select o from Order o where o.user = :user)")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -21,18 +21,11 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     Optional<Delivery> findByOrderIdWithOrder(@Param("orderId") Long orderId);
 
     @Query(value = "select d from Delivery d"
-        + " join fetch d.order"
-        + " where d.deliveryStatus"
-        + " = com.prgrms.nabmart.domain.delivery.DeliveryStatus.ACCEPTING_ORDER",
-    countQuery = "select d.deliveryId from Delivery d"
         + " where d.deliveryStatus"
         + " = com.prgrms.nabmart.domain.delivery.DeliveryStatus.ACCEPTING_ORDER")
     Page<Delivery> findWaitingDeliveries(Pageable pageable);
 
     @Query(value = "select d from Delivery d"
-        + " join fetch d.order"
-        + " where d.rider = :rider and d.deliveryStatus in :statuses",
-    countQuery = "select d.deliveryId from Delivery d"
         + " where d.rider = :rider and d.deliveryStatus in :statuses")
     Page<Delivery> findRiderDeliveries(
         @Param("rider") Rider rider,

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
@@ -7,18 +7,22 @@ import java.time.LocalDateTime;
 public record FindDeliveryDetailResponse(
     Long deliveryId,
     DeliveryStatus deliveryStatus,
+    LocalDateTime createdAt,
     LocalDateTime arrivedAt,
     Long orderId,
-    String name,
-    int price) {
+    String orderName,
+    int orderPrice,
+    String riderRequest) {
 
     public static FindDeliveryDetailResponse from(final Delivery delivery) {
         return new FindDeliveryDetailResponse(
             delivery.getDeliveryId(),
             delivery.getDeliveryStatus(),
+            delivery.getCreatedAt(),
             delivery.getArrivedAt(),
             delivery.getOrder().getOrderId(),
             delivery.getOrder().getName(),
-            delivery.getOrder().getPrice());
+            delivery.getOrder().getPrice(),
+            delivery.getOrder().getRiderRequest());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindDeliveryDetailResponse.java
@@ -22,7 +22,7 @@ public record FindDeliveryDetailResponse(
             delivery.getArrivedAt(),
             delivery.getOrder().getOrderId(),
             delivery.getOrder().getName(),
-            delivery.getOrder().getPrice(),
-            delivery.getOrder().getRiderRequest());
+            delivery.getOrderPrice(),
+            delivery.getRiderRequest());
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
@@ -27,7 +27,10 @@ public record FindRiderDeliveriesResponse(
         Long deliveryId,
         DeliveryStatus deliveryStatus,
         LocalDateTime arrivedAt,
+        LocalDateTime createdAt,
         String address,
+        int orderPrice,
+        String riderRequest,
         int deliveryFee) {
 
         public static FindRiderDeliveryResponse from(final Delivery delivery) {
@@ -35,7 +38,10 @@ public record FindRiderDeliveriesResponse(
                 delivery.getDeliveryId(),
                 delivery.getDeliveryStatus(),
                 delivery.getArrivedAt(),
+                delivery.getCreatedAt(),
                 delivery.getOrder().getAddress(),
+                delivery.getOrder().getPrice(),
+                delivery.getOrder().getRiderRequest(),
                 delivery.getOrder().getDeliveryFee());
         }
     }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindRiderDeliveriesResponse.java
@@ -39,10 +39,10 @@ public record FindRiderDeliveriesResponse(
                 delivery.getDeliveryStatus(),
                 delivery.getArrivedAt(),
                 delivery.getCreatedAt(),
-                delivery.getOrder().getAddress(),
-                delivery.getOrder().getPrice(),
-                delivery.getOrder().getRiderRequest(),
-                delivery.getOrder().getDeliveryFee());
+                delivery.getAddress(),
+                delivery.getOrderPrice(),
+                delivery.getRiderRequest(),
+                delivery.getDeliveryFee());
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
@@ -32,8 +32,8 @@ public record FindWaitingDeliveriesResponse(
                 delivery.getDeliveryId(),
                 delivery.getArrivedAt(),
                 delivery.getCreatedAt(),
-                delivery.getOrder().getAddress(),
-                delivery.getOrder().getDeliveryFee());
+                delivery.getAddress(),
+                delivery.getDeliveryFee());
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/response/FindWaitingDeliveriesResponse.java
@@ -1,6 +1,7 @@
 package com.prgrms.nabmart.domain.delivery.service.response;
 
 import com.prgrms.nabmart.domain.delivery.Delivery;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
@@ -19,11 +20,20 @@ public record FindWaitingDeliveriesResponse(
             deliveryResponses.getTotalElements());
     }
 
-    public record FindWaitingDeliveryResponse(Long deliveryId) {
+    public record FindWaitingDeliveryResponse(
+        Long deliveryId,
+        LocalDateTime arrivedAt,
+        LocalDateTime createdAt,
+        String address,
+        int deliveryFee) {
 
         public static FindWaitingDeliveryResponse from(final Delivery delivery) {
             return new FindWaitingDeliveryResponse(
-                delivery.getDeliveryId());
+                delivery.getDeliveryId(),
+                delivery.getArrivedAt(),
+                delivery.getCreatedAt(),
+                delivery.getOrder().getAddress(),
+                delivery.getOrder().getDeliveryFee());
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/LikeItemRepository.java
@@ -15,4 +15,6 @@ public interface LikeItemRepository extends JpaRepository<LikeItem, Long> {
 
     @Query("select li from LikeItem li join fetch li.item where li.user = :user")
     Page<LikeItem> findByUserWithItem(@Param("user") User user, Pageable pageable);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.prgrms.nabmart.domain.order.repository;
 
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.order.OrderStatus;
+import com.prgrms.nabmart.domain.user.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -21,4 +22,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o WHERE o.createdAt <= :expiredTime AND o.status IN :statusList")
     List<Order> findByStatusInBeforeExpiredTime(LocalDateTime expiredTime,
         List<OrderStatus> statusList);
+
+    void deleteByUser(User findUser);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/repository/PaymentRepository.java
@@ -1,10 +1,13 @@
 package com.prgrms.nabmart.domain.payment.repository;
 
 import com.prgrms.nabmart.domain.payment.Payment;
+import com.prgrms.nabmart.domain.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByOrder_UuidAndUser_UserId(String uuid, Long userId);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/review/repository/ReviewRepository.java
@@ -13,4 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByItemOrderByCreatedAt(Item item);
 
     Long countByItem_ItemId(Long itemId);
+
+    void deleteByUser(User findUser);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -1,5 +1,13 @@
 package com.prgrms.nabmart.domain.user.service;
 
+import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
+import com.prgrms.nabmart.domain.cart.repository.CartRepository;
+import com.prgrms.nabmart.domain.coupon.repository.UserCouponRepository;
+import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
+import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
+import com.prgrms.nabmart.domain.order.repository.OrderRepository;
+import com.prgrms.nabmart.domain.payment.repository.PaymentRepository;
+import com.prgrms.nabmart.domain.review.repository.ReviewRepository;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
@@ -16,6 +24,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final LikeItemRepository likeItemRepository;
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final OrderRepository orderRepository;
+    private final DeliveryRepository deliveryRepository;
+    private final PaymentRepository paymentRepository;
 
     @Transactional
     public RegisterUserResponse getOrRegisterUser(final RegisterUserCommand registerUserCommand) {
@@ -47,7 +63,16 @@ public class UserService {
 
     @Transactional
     public void deleteUser(Long userId) {
-        userRepository.deleteById(userId);
+        User findUser = findUserByUserId(userId);
+        reviewRepository.deleteByUser(findUser);
+        likeItemRepository.deleteByUser(findUser);
+        cartItemRepository.deleteByUser(findUser);
+        cartRepository.deleteByUser(findUser);
+        deliveryRepository.deleteByUser(findUser);
+        paymentRepository.deleteByUser(findUser);
+        orderRepository.deleteByUser(findUser);
+        userCouponRepository.deleteByUser(findUser);
+        userRepository.delete(findUser);
     }
 
     private User findUserByUserId(Long userId) {

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -71,7 +71,6 @@ public class UserService {
         likeItemRepository.deleteByUser(findUser);
         cartItemRepository.deleteByUser(findUser);
         cartRepository.deleteByUser(findUser);
-        deliveryRepository.deleteByUser(findUser);
         paymentRepository.deleteByUser(findUser);
         orderRepository.deleteByUser(findUser);
         userCouponRepository.deleteByUser(findUser);

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.prgrms.nabmart.domain.user.service;
 import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
 import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.coupon.repository.UserCouponRepository;
+import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.order.repository.OrderRepository;
@@ -15,6 +16,7 @@ import com.prgrms.nabmart.domain.user.service.request.FindUserCommand;
 import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
 import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import com.prgrms.nabmart.domain.user.service.response.RegisterUserResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +66,7 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User findUser = findUserByUserId(userId);
+        releaseDeliveryAboutUserInfo(findUser);
         reviewRepository.deleteByUser(findUser);
         likeItemRepository.deleteByUser(findUser);
         cartItemRepository.deleteByUser(findUser);
@@ -73,6 +76,11 @@ public class UserService {
         orderRepository.deleteByUser(findUser);
         userCouponRepository.deleteByUser(findUser);
         userRepository.delete(findUser);
+    }
+
+    private void releaseDeliveryAboutUserInfo(User findUser) {
+        List<Delivery> userDeliveries = deliveryRepository.findAllByUser(findUser);
+        userDeliveries.forEach(Delivery::deleteAboutUser);
     }
 
     private User findUserByUserId(Long userId) {

--- a/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
@@ -91,5 +91,9 @@ public abstract class IntegrationTest {
         properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
         properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
         properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+        properties.setProperty("REDIS_HOST", "localhost");
+        properties.setProperty("REDIS_PORT", "6379");
+        properties.setProperty("spring.data.redis.host", "localhost");
+        properties.setProperty("spring.data.redis.port", "6379");
     }
 }

--- a/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/IntegrationTest.java
@@ -91,5 +91,7 @@ public abstract class IntegrationTest {
         properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
         properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
         properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+        properties.setProperty("REDIS_HOST", "localhost");
+        properties.setProperty("REDIS_PORT", "6379");
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
@@ -2,35 +2,91 @@ package com.prgrms.nabmart.domain.delivery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.prgrms.nabmart.base.IntegrationTest;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.category.fixture.CategoryFixture;
+import com.prgrms.nabmart.domain.category.repository.MainCategoryRepository;
+import com.prgrms.nabmart.domain.category.repository.SubCategoryRepository;
+import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
 import com.prgrms.nabmart.domain.delivery.service.DeliveryService;
 import com.prgrms.nabmart.domain.delivery.service.request.AcceptDeliveryCommand;
 import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.order.OrderItem;
+import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
+import com.prgrms.nabmart.domain.order.repository.OrderRepository;
 import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-@Disabled("다른 테스트와 충돌 발생_해결 필요")
-public class DeliveryIntegrationTest extends IntegrationTest {
+@SpringBootTest
+public class DeliveryIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    MainCategoryRepository mainCategoryRepository;
+
+    @Autowired
+    SubCategoryRepository subCategoryRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    OrderItemRepository orderItemRepository;
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    DeliveryRepository deliveryRepository;
 
     @Autowired
     DeliveryService deliveryService;
+
+    @Autowired
+    RiderRepository riderRepository;
+
+    @BeforeAll
+    static void beforeAll() {
+        Properties properties = System.getProperties();
+        properties.setProperty("ISSUER", "issuer");
+        properties.setProperty("CLIENT_SECRET", "clientSecret");
+        properties.setProperty("NAVER_CLIENT_ID", "naverClientId");
+        properties.setProperty("NAVER_CLIENT_SECRET", "naverClientSecret");
+        properties.setProperty("KAKAO_CLIENT_ID", "kakaoClientId");
+        properties.setProperty("KAKAO_CLIENT_SECRET", "kakaoClientSecret");
+        properties.setProperty("REDIRECT_URI",
+            "http://localhost:8080/login/oauth2/code/{registrationId}");
+        properties.setProperty("EXPIRY_SECONDS", "60");
+        properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
+        properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
+        properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+        properties.setProperty("REDIS_HOST", "localhost");
+        properties.setProperty("REDIS_PORT", "6379");
+        properties.setProperty("spring.data.redis.host", "localhost");
+        properties.setProperty("spring.data.redis.port", "6379");
+    }
+
 
     @Nested
     @DisplayName("acceptDelivery 메서드 실행 시")
@@ -77,6 +133,16 @@ public class DeliveryIntegrationTest extends IntegrationTest {
             Delivery delivery = new Delivery(order);
             deliveryRepository.save(delivery);
             return delivery;
+        }
+
+        @AfterEach
+        void tearDown() {
+            deliveryRepository.deleteAll();
+            riderRepository.deleteAll();
+            orderRepository.deleteAll();
+            itemRepository.deleteAll();
+            subCategoryRepository.deleteAll();
+            mainCategoryRepository.deleteAll();
         }
 
         @Test

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/DeliveryIntegrationTest.java
@@ -20,11 +20,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@Disabled("다른 테스트와 충돌 발생_해결 필요")
 public class DeliveryIntegrationTest extends IntegrationTest {
 
     @Autowired
@@ -58,7 +60,6 @@ public class DeliveryIntegrationTest extends IntegrationTest {
             itemRepository.save(item);
             orderRepository.save(order);
         }
-
 
         List<Rider> createAndSaveRiders(int end) {
             List<Rider> riders = IntStream.range(0, end)

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -68,11 +68,13 @@ class DeliveryControllerTest extends BaseControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("deliveryId").type(NUMBER).description("배달 ID"),
-                        fieldWithPath("deliveryStatus").type(STRING).description("배달 ID"),
-                        fieldWithPath("arrivedAt").type(STRING).description("도착 시간"),
+                        fieldWithPath("deliveryStatus").type(STRING).description("배달 상태"),
+                        fieldWithPath("createdAt").type(STRING).description("배달 생성 시각"),
+                        fieldWithPath("arrivedAt").type(STRING).description("배달 완료 예정 시각"),
                         fieldWithPath("orderId").type(NUMBER).description("주문 ID"),
-                        fieldWithPath("name").type(STRING).description("주문 이름"),
-                        fieldWithPath("price").type(NUMBER).description("주문 가격")
+                        fieldWithPath("orderName").type(STRING).description("주문 이름"),
+                        fieldWithPath("orderPrice").type(NUMBER).description("주문 가격"),
+                        fieldWithPath("riderRequest").type(STRING).description("배달원 요청 사항")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -216,7 +216,16 @@ class DeliveryControllerTest extends BaseControllerTest {
                     ),
                     responseFields(
                         fieldWithPath("deliveries").type(ARRAY).description("배달 목록"),
-                        fieldWithPath("deliveries[].deliveryId").type(NUMBER).description("배달 ID"),
+                        fieldWithPath("deliveries[].deliveryId").type(NUMBER)
+                            .description("배달 ID"),
+                        fieldWithPath("deliveries[].arrivedAt").type(STRING)
+                            .description("배달 완료 예정 시간"),
+                        fieldWithPath("deliveries[].createdAt").type(STRING)
+                            .description("배달 접수 시간"),
+                        fieldWithPath("deliveries[].address").type(STRING)
+                            .description("배달 목적지"),
+                        fieldWithPath("deliveries[].deliveryFee").type(NUMBER)
+                            .description("배달비"),
                         fieldWithPath("page").type(NUMBER).description("페이지"),
                         fieldWithPath("totalElements").type(NUMBER).description("사이즈")
                     )

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -53,7 +53,7 @@ class DeliveryControllerTest extends BaseControllerTest {
 
             //when
             ResultActions resultActions = mockMvc
-                .perform(get("/api/v1/deliveries/{orderId}", orderId)
+                .perform(get("/api/v1/orders/{orderId}/deliveries", orderId)
                     .header(AUTHORIZATION, accessToken)
                     .accept(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -246,7 +246,10 @@ class DeliveryControllerTest extends BaseControllerTest {
                 1L,
                 deliveryStatus,
                 LocalDateTime.now().plusMinutes(20),
+                LocalDateTime.now(),
                 "address",
+                15000,
+                "문 앞에 두고 벨 눌러주세요.",
                 3000
             );
             FindRiderDeliveriesResponse findRiderDeliveriesResponse
@@ -275,6 +278,27 @@ class DeliveryControllerTest extends BaseControllerTest {
                         parameterWithName("deliveryStatuses").description("배달 상태 목록"),
                         parameterWithName("page").description("페이지"),
                         parameterWithName("size").description("페이지 사이즈")
+                    ),
+                    responseFields(
+                        fieldWithPath("deliveries").type(ARRAY).description("배달 목록"),
+                        fieldWithPath("deliveries[].deliveryId").type(NUMBER)
+                            .description("배달 ID"),
+                        fieldWithPath("deliveries[].deliveryStatus").type(STRING)
+                            .description("배달 상태"),
+                        fieldWithPath("deliveries[].arrivedAt").type(STRING)
+                            .description("배달 완료 예정 시각"),
+                        fieldWithPath("deliveries[].createdAt").type(STRING)
+                            .description("배달 생성 시각"),
+                        fieldWithPath("deliveries[].address").type(STRING)
+                            .description("배달 목적지"),
+                        fieldWithPath("deliveries[].orderPrice").type(NUMBER)
+                            .description("주문 가격"),
+                        fieldWithPath("deliveries[].riderRequest").type(STRING)
+                            .description("배달원 요청 사항"),
+                        fieldWithPath("deliveries[].deliveryFee").type(NUMBER)
+                            .description("배달비"),
+                        fieldWithPath("page").type(NUMBER).description("페이지"),
+                        fieldWithPath("totalElements").type(NUMBER).description("총 요소 갯수")
                     )
                 ));
         }

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -95,11 +95,15 @@ class DeliveryServiceTest {
             assertThat(findDeliveryDetailResponse.deliveryStatus())
                 .isEqualTo(delivery.getDeliveryStatus());
             assertThat(findDeliveryDetailResponse.arrivedAt())
+                .isEqualTo(delivery.getCreatedAt());
+            assertThat(findDeliveryDetailResponse.arrivedAt())
                 .isEqualTo(delivery.getArrivedAt());
-            assertThat(findDeliveryDetailResponse.name())
+            assertThat(findDeliveryDetailResponse.orderName())
                 .isEqualTo(delivery.getOrder().getName());
-            assertThat(findDeliveryDetailResponse.price())
+            assertThat(findDeliveryDetailResponse.orderPrice())
                 .isEqualTo(delivery.getOrder().getPrice());
+            assertThat(findDeliveryDetailResponse.riderRequest())
+                .isEqualTo(delivery.getOrder().getRiderRequest());
         }
 
         @Test

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -53,10 +53,11 @@ public final class DeliveryFixture {
             DELIVERY_ID,
             DELIVERY_STATUS,
             NOW,
+            NOW,
             ORDER_ID,
             ORDER_NAME,
-            ORDER_PRICE
-        );
+            ORDER_PRICE,
+            RIDER_REQUEST);
     }
 
     public static FindWaitingDeliveriesResponse findDeliveriesResponse() {

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -19,12 +19,13 @@ public final class DeliveryFixture {
     private static final Long DELIVERY_ID = 1L;
     private static final String ADDRESS = "주소지";
     private static final int DELIVERY_FEE = 3000;
-    private static final LocalDateTime ARRIVED_AT = LocalDateTime.now();
+    private static final LocalDateTime NOW = LocalDateTime.now();
     private static final DeliveryStatus DELIVERY_STATUS = DeliveryStatus.ACCEPTING_ORDER;
     private static final Long USER_ID = 1L;
     private static final Long ORDER_ID = 1L;
     private static final String ORDER_NAME = "비비고 왕교자 외 2개";
     private static final int ORDER_PRICE = 1000;
+    private static final String RIDER_REQUEST = "문 앞에 두고 벨 눌러주세요.";
     private static final int ESTIMATE_MINUTES = 20;
     private static final int PAGE = 0;
     private static final String RIDER_USERNAME = "username";
@@ -51,7 +52,7 @@ public final class DeliveryFixture {
         return new FindDeliveryDetailResponse(
             DELIVERY_ID,
             DELIVERY_STATUS,
-            ARRIVED_AT,
+            NOW,
             ORDER_ID,
             ORDER_NAME,
             ORDER_PRICE
@@ -60,7 +61,7 @@ public final class DeliveryFixture {
 
     public static FindWaitingDeliveriesResponse findDeliveriesResponse() {
         FindWaitingDeliveryResponse findWaitingDeliveryResponse
-            = new FindWaitingDeliveryResponse(DELIVERY_ID);
+            = new FindWaitingDeliveryResponse(DELIVERY_ID, NOW, NOW, ADDRESS, DELIVERY_FEE);
         return new FindWaitingDeliveriesResponse(List.of(findWaitingDeliveryResponse), PAGE, 1);
     }
 

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/support/DeliveryFixture.java
@@ -43,6 +43,12 @@ public final class DeliveryFixture {
         return delivery;
     }
 
+    public static Delivery completedDelivery(Order order, Rider rider) {
+        Delivery delivery = acceptedDelivery(order, rider);
+        delivery.completeDelivery();
+        return delivery;
+    }
+
     public static FindDeliveryCommand findDeliveryCommand() {
         return new FindDeliveryCommand(USER_ID, ORDER_ID);
     }

--- a/src/test/java/com/prgrms/nabmart/domain/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/OrderServiceIntegrationTest.java
@@ -42,6 +42,8 @@ public class OrderServiceIntegrationTest {
         properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
         properties.setProperty("REDIS_HOST", "redisHost");
         properties.setProperty("REDIS_PORT", "6379");
+        properties.setProperty("spring.data.redis.host", "localhost");
+        properties.setProperty("spring.data.redis.port", "6379");
     }
 
     @Autowired

--- a/src/test/java/com/prgrms/nabmart/domain/payment/support/PaymentFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/support/PaymentFixture.java
@@ -24,4 +24,10 @@ public class PaymentFixture {
 
         return payment;
     }
+
+    public static Payment successPayment(User user, Order order) {
+        Payment payment = pendingPayment(user, order);
+        ReflectionTestUtils.setField(payment, "paymentStatus", PaymentStatus.SUCCESS);
+        return payment;
+    }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
@@ -151,5 +151,21 @@ public class UserIntegrationTest extends IntegrationTest {
             assertThat(riderRepository.findById(rider.getRiderId())).isNotEmpty();
             assertThat(deliveryRepository.findById(delivery.getDeliveryId())).isNotEmpty();
         }
+
+        @Test
+        @DisplayName("성공: Delivery와 User 관련 필드 업데이트")
+        void successDeliveryUpdate() {
+            //given
+            Long userId = user.getUserId();
+
+            //when
+            userService.deleteUser(userId);
+            em.flush();
+            em.clear();
+
+            //then
+            assertThat(delivery.getAddress()).isEqualTo("삭제됨");
+            assertThat(delivery.getOrder()).isNull();
+        }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
@@ -2,45 +2,29 @@ package com.prgrms.nabmart.domain.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.prgrms.nabmart.base.IntegrationTest;
 import com.prgrms.nabmart.domain.cart.Cart;
 import com.prgrms.nabmart.domain.cart.CartItem;
-import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
-import com.prgrms.nabmart.domain.cart.repository.CartRepository;
 import com.prgrms.nabmart.domain.cart.support.CartFixture;
 import com.prgrms.nabmart.domain.cart.support.CartItemFixture;
 import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.category.fixture.CategoryFixture;
-import com.prgrms.nabmart.domain.category.repository.MainCategoryRepository;
-import com.prgrms.nabmart.domain.category.repository.SubCategoryRepository;
 import com.prgrms.nabmart.domain.coupon.Coupon;
 import com.prgrms.nabmart.domain.coupon.UserCoupon;
-import com.prgrms.nabmart.domain.coupon.repository.CouponRepository;
-import com.prgrms.nabmart.domain.coupon.repository.UserCouponRepository;
 import com.prgrms.nabmart.domain.coupon.support.CouponFixture;
 import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.Rider;
-import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
-import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
 import com.prgrms.nabmart.domain.delivery.support.DeliveryFixture;
-import com.prgrms.nabmart.domain.event.repository.EventItemRepository;
-import com.prgrms.nabmart.domain.event.repository.EventRepository;
 import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.LikeItem;
-import com.prgrms.nabmart.domain.item.repository.ItemRepository;
-import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.order.Order;
 import com.prgrms.nabmart.domain.order.OrderItem;
-import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
-import com.prgrms.nabmart.domain.order.repository.OrderRepository;
 import com.prgrms.nabmart.domain.payment.Payment;
-import com.prgrms.nabmart.domain.payment.repository.PaymentRepository;
 import com.prgrms.nabmart.domain.payment.support.PaymentFixture;
 import com.prgrms.nabmart.domain.review.Review;
-import com.prgrms.nabmart.domain.review.repository.ReviewRepository;
 import com.prgrms.nabmart.domain.review.support.ReviewFixture;
-import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.service.UserService;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
 import jakarta.persistence.EntityManager;
@@ -57,58 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
-public class UserIntegrationTest {
-
-    @Autowired
-    protected CartItemRepository cartItemRepository;
-
-    @Autowired
-    protected CartRepository cartRepository;
-
-    @Autowired
-    protected MainCategoryRepository mainCategoryRepository;
-
-    @Autowired
-    protected SubCategoryRepository subCategoryRepository;
-
-    @Autowired
-    protected CouponRepository couponRepository;
-
-    @Autowired
-    protected UserCouponRepository userCouponRepository;
-
-    @Autowired
-    protected DeliveryRepository deliveryRepository;
-
-    @Autowired
-    protected RiderRepository riderRepository;
-
-    @Autowired
-    protected EventItemRepository eventItemRepository;
-
-    @Autowired
-    protected EventRepository eventRepository;
-
-    @Autowired
-    protected ItemRepository itemRepository;
-
-    @Autowired
-    protected LikeItemRepository likeItemRepository;
-
-    @Autowired
-    protected OrderItemRepository orderItemRepository;
-
-    @Autowired
-    protected OrderRepository orderRepository;
-
-    @Autowired
-    protected PaymentRepository paymentRepository;
-
-    @Autowired
-    protected ReviewRepository reviewRepository;
-
-    @Autowired
-    protected UserRepository userRepository;
+public class UserIntegrationTest extends IntegrationTest {
 
     @BeforeAll
     static void beforeAll() {

--- a/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
@@ -122,7 +122,6 @@ public class UserIntegrationTest extends IntegrationTest {
             //then
             assertThat(orderRepository.findById(order.getOrderId())).isEmpty();
             assertThat(orderItemRepository.findById(orderItem.getOrderItemId())).isEmpty();
-            assertThat(deliveryRepository.findById(delivery.getDeliveryId())).isEmpty();
             assertThat(reviewRepository.findById(review.getReviewId())).isEmpty();
             assertThat(likeItemRepository.findById(likeItem.getLikeItemId())).isEmpty();
             assertThat(cartItemRepository.findById(cartItem.getCartItemId())).isEmpty();
@@ -133,7 +132,7 @@ public class UserIntegrationTest extends IntegrationTest {
         }
 
         @Test
-        @DisplayName("성공: 유저와 연관되지 않은 데이터는 삭제되지 않음")
+        @DisplayName("성공: 서비스와 연관된 데이터는 삭제되지 않음")
         void successWhenServiceDataStillAlive() {
             //given
             Long userId = user.getUserId();
@@ -150,6 +149,7 @@ public class UserIntegrationTest extends IntegrationTest {
             assertThat(itemRepository.findById(item.getItemId())).isNotEmpty();
             assertThat(couponRepository.findById(coupon.getCouponId())).isNotEmpty();
             assertThat(riderRepository.findById(rider.getRiderId())).isNotEmpty();
+            assertThat(deliveryRepository.findById(delivery.getDeliveryId())).isNotEmpty();
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/UserIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.prgrms.nabmart.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prgrms.nabmart.domain.cart.Cart;
+import com.prgrms.nabmart.domain.cart.CartItem;
+import com.prgrms.nabmart.domain.cart.repository.CartItemRepository;
+import com.prgrms.nabmart.domain.cart.repository.CartRepository;
+import com.prgrms.nabmart.domain.cart.support.CartFixture;
+import com.prgrms.nabmart.domain.cart.support.CartItemFixture;
+import com.prgrms.nabmart.domain.category.MainCategory;
+import com.prgrms.nabmart.domain.category.SubCategory;
+import com.prgrms.nabmart.domain.category.fixture.CategoryFixture;
+import com.prgrms.nabmart.domain.category.repository.MainCategoryRepository;
+import com.prgrms.nabmart.domain.category.repository.SubCategoryRepository;
+import com.prgrms.nabmart.domain.coupon.Coupon;
+import com.prgrms.nabmart.domain.coupon.UserCoupon;
+import com.prgrms.nabmart.domain.coupon.repository.CouponRepository;
+import com.prgrms.nabmart.domain.coupon.repository.UserCouponRepository;
+import com.prgrms.nabmart.domain.coupon.support.CouponFixture;
+import com.prgrms.nabmart.domain.delivery.Delivery;
+import com.prgrms.nabmart.domain.delivery.Rider;
+import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
+import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
+import com.prgrms.nabmart.domain.delivery.support.DeliveryFixture;
+import com.prgrms.nabmart.domain.event.repository.EventItemRepository;
+import com.prgrms.nabmart.domain.event.repository.EventRepository;
+import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.LikeItem;
+import com.prgrms.nabmart.domain.item.repository.ItemRepository;
+import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
+import com.prgrms.nabmart.domain.item.support.ItemFixture;
+import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.order.OrderItem;
+import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
+import com.prgrms.nabmart.domain.order.repository.OrderRepository;
+import com.prgrms.nabmart.domain.payment.Payment;
+import com.prgrms.nabmart.domain.payment.repository.PaymentRepository;
+import com.prgrms.nabmart.domain.payment.support.PaymentFixture;
+import com.prgrms.nabmart.domain.review.Review;
+import com.prgrms.nabmart.domain.review.repository.ReviewRepository;
+import com.prgrms.nabmart.domain.review.support.ReviewFixture;
+import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import com.prgrms.nabmart.domain.user.service.UserService;
+import com.prgrms.nabmart.domain.user.support.UserFixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class UserIntegrationTest {
+
+    @Autowired
+    protected CartItemRepository cartItemRepository;
+
+    @Autowired
+    protected CartRepository cartRepository;
+
+    @Autowired
+    protected MainCategoryRepository mainCategoryRepository;
+
+    @Autowired
+    protected SubCategoryRepository subCategoryRepository;
+
+    @Autowired
+    protected CouponRepository couponRepository;
+
+    @Autowired
+    protected UserCouponRepository userCouponRepository;
+
+    @Autowired
+    protected DeliveryRepository deliveryRepository;
+
+    @Autowired
+    protected RiderRepository riderRepository;
+
+    @Autowired
+    protected EventItemRepository eventItemRepository;
+
+    @Autowired
+    protected EventRepository eventRepository;
+
+    @Autowired
+    protected ItemRepository itemRepository;
+
+    @Autowired
+    protected LikeItemRepository likeItemRepository;
+
+    @Autowired
+    protected OrderItemRepository orderItemRepository;
+
+    @Autowired
+    protected OrderRepository orderRepository;
+
+    @Autowired
+    protected PaymentRepository paymentRepository;
+
+    @Autowired
+    protected ReviewRepository reviewRepository;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @BeforeAll
+    static void beforeAll() {
+        Properties properties = System.getProperties();
+        properties.setProperty("ISSUER", "issuer");
+        properties.setProperty("CLIENT_SECRET", "clientSecret");
+        properties.setProperty("NAVER_CLIENT_ID", "naverClientId");
+        properties.setProperty("NAVER_CLIENT_SECRET", "naverClientSecret");
+        properties.setProperty("KAKAO_CLIENT_ID", "kakaoClientId");
+        properties.setProperty("KAKAO_CLIENT_SECRET", "kakaoClientSecret");
+        properties.setProperty("REDIRECT_URI",
+            "http://localhost:8080/login/oauth2/code/{registrationId}");
+        properties.setProperty("EXPIRY_SECONDS", "60");
+        properties.setProperty("TOSS_SUCCESS_URL", "tossSuccessUrl");
+        properties.setProperty("TOSS_FAIL_URL", "tossFailUrl");
+        properties.setProperty("TOSS_SECRET_KEY", "tossSecretKey");
+        properties.setProperty("REDIS_HOST", "localhost");
+        properties.setProperty("REDIS_PORT", "6379");
+        properties.setProperty("spring.data.redis.host", "localhost");
+        properties.setProperty("spring.data.redis.port", "6379");
+    }
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    EntityManager em;
+
+    protected User user = UserFixture.user();
+    protected MainCategory mainCategory = CategoryFixture.mainCategory();
+    protected SubCategory subCategory = CategoryFixture.subCategory(mainCategory);
+    protected Item item = ItemFixture.item(mainCategory, subCategory);
+    protected Cart cart = CartFixture.cart(user);
+    protected CartItem cartItem = CartItemFixture.cartItem(cart, item, 5);
+    protected Review review = ReviewFixture.review(user, item);
+    protected LikeItem likeItem = ItemFixture.likeItem(user, item);
+    protected Coupon coupon = CouponFixture.coupon();
+    protected UserCoupon userCoupon = new UserCoupon(user, coupon);
+    protected OrderItem orderItem = new OrderItem(item, 5);
+    protected Order order = new Order(user, List.of(orderItem));
+    protected Payment payment = PaymentFixture.pendingPayment(user, order);
+    protected Rider rider = DeliveryFixture.rider();
+    protected Delivery delivery = DeliveryFixture.completedDelivery(order, rider);
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(user);
+        mainCategoryRepository.save(mainCategory);
+        subCategoryRepository.save(subCategory);
+        itemRepository.save(item);
+        cartRepository.save(cart);
+        cartItemRepository.save(cartItem);
+        reviewRepository.save(review);
+        likeItemRepository.save(likeItem);
+        couponRepository.save(coupon);
+        userCouponRepository.save(userCoupon);
+        orderRepository.save(order);
+        paymentRepository.save(payment);
+        riderRepository.save(rider);
+        deliveryRepository.save(delivery);
+    }
+
+    @Nested
+    @DisplayName("유저 삭제 시 연과된 엔티티도 삭제된다.")
+    class DeleteUserTest {
+
+        @Test
+        @DisplayName("성공: 유저와 연관된 데이터는 삭제")
+        void successWhenUserDataIsDeleted() {
+            //given
+            Long userId = user.getUserId();
+
+            //when
+            userService.deleteUser(userId);
+            em.flush();
+            em.clear();
+
+            //then
+            assertThat(orderRepository.findById(order.getOrderId())).isEmpty();
+            assertThat(orderItemRepository.findById(orderItem.getOrderItemId())).isEmpty();
+            assertThat(deliveryRepository.findById(delivery.getDeliveryId())).isEmpty();
+            assertThat(reviewRepository.findById(review.getReviewId())).isEmpty();
+            assertThat(likeItemRepository.findById(likeItem.getLikeItemId())).isEmpty();
+            assertThat(cartItemRepository.findById(cartItem.getCartItemId())).isEmpty();
+            assertThat(cartRepository.findById(cart.getCartId())).isEmpty();
+            assertThat(paymentRepository.findById(payment.getPayId())).isEmpty();
+            assertThat(userCouponRepository.findById(userCoupon.getUserCouponId())).isEmpty();
+            assertThat(userRepository.findById(user.getUserId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: 유저와 연관되지 않은 데이터는 삭제되지 않음")
+        void successWhenServiceDataStillAlive() {
+            //given
+            Long userId = user.getUserId();
+
+            //when
+            userService.deleteUser(userId);
+            em.flush();
+            em.clear();
+
+            //when
+            assertThat(
+                mainCategoryRepository.findById(mainCategory.getMainCategoryId())).isNotEmpty();
+            assertThat(subCategoryRepository.findById(subCategory.getSubCategoryId())).isNotEmpty();
+            assertThat(itemRepository.findById(item.getItemId())).isNotEmpty();
+            assertThat(couponRepository.findById(coupon.getCouponId())).isNotEmpty();
+            assertThat(riderRepository.findById(rider.getRiderId())).isNotEmpty();
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 사용자 삭제시 사용자와 연관된 데이터를 삭제하도록 작업하였습니다.
- `Delivery`의 경우 라이더에게 중요한 데이터이기에 제거하지 않고 남겨두었습니다. 더하여 조회시 빈번한 조인이 일어나는 `Order`의 일부 필드들을 반정규화 하였습니다.
- `리뷰`, `찜 상품`, `장바구니`, `장바구니 상품`, `결제내역`, `주문`, `유저쿠폰`, `유저`가 삭제됩니다.
- `상품`, `카테고리`, `이벤트`, `쿠폰`, `라이더`는 삭제되지 않습니다.
- `배달`은 `상품`과의 연관관계를 끊고 주소 정보가 "삭제됨"이라는 텍스트로 대체됩니다.


### 📝 작업 요약
- `Delivery` 반정규화(address, price, deliveryFee, riderRequest 추가)
- 사용자와 연관된 엔티티 하드 딜리트


### 💡 관련 이슈
- [NAYB-81](https://naybmart.atlassian.net/browse/NAYB-81)



[NAYB-81]: https://naybmart.atlassian.net/browse/NAYB-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ