### PR TITLE
[NAYB-138] 결제 실패할 경우를 처리한다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/coupon/UserCoupon.java
+++ b/src/main/java/com/prgrms/nabmart/domain/coupon/UserCoupon.java
@@ -51,5 +51,12 @@ public class UserCoupon extends BaseTimeEntity {
         }
         isUsed = true;
     }
+
+    public void unUse() {
+        if (isUsed == false) {
+            throw new InvalidUsedCouponException("사용하지 않은 쿠폰입니다.");
+        }
+        isUsed = false;
+    }
 }
 

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,6 +20,10 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select i from Item i where i.itemId = :itemId")
     Optional<Item> findByItemId(@Param("itemId") Long itemId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update Item i set i.quantity = i.quantity + :quantity where i.itemId = :itemId")
+    void increaseQuantity(@Param("itemId") Long itemId, @Param("quantity") int quantity);
 
     @Query("select i from Item i where i.itemId in ?1")
     List<Item> findByItemIdIn(Collection<Long> itemIds);

--- a/src/main/java/com/prgrms/nabmart/domain/order/Order.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/Order.java
@@ -117,7 +117,7 @@ public class Order extends BaseTimeEntity {
         this.price -= userCoupon.getDiscount();
 
     }
-    
+
     private void calculateDeliveryFee(final int totalPrice) {
         if (totalPrice >= 43000) {
             this.deliveryFee = 0;
@@ -150,9 +150,15 @@ public class Order extends BaseTimeEntity {
         this.status = orderStatus;
     }
 
-    public void redeemCoupon() {
+    public void useCoupon() {
         if (userCoupon != null) {
             userCoupon.use();
+        }
+    }
+
+    public void unUseCoupon() {
+        if (userCoupon != null) {
+            userCoupon.unUse();
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/order/service/OrderService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/service/OrderService.java
@@ -145,6 +145,11 @@ public class OrderService {
             .orElseThrow(() -> new NotFoundOrderException("order 가 존재하지 않습니다"));
     }
 
+    public Order getOrderByUuidAndUserId(final String uuid, final Long userId) {
+        return orderRepository.findByUuidAndUser_UserId(uuid, userId)
+            .orElseThrow(() -> new NotFoundOrderException("order 가 존재하지 않습니다"));
+    }
+
     private User findUserByUserId(final Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new NotFoundUserException("존재하지 않은 사용자입니다."));
@@ -153,5 +158,15 @@ public class OrderService {
     private Item findItemByItemId(final Long itemId) {
         return itemRepository.findByItemId(itemId)
             .orElseThrow(() -> new NotFoundItemException("존재하지 않는 상품입니다."));
+    }
+
+    @Transactional
+    public void cancelOrder(final Order order) {
+        order.updateOrderStatus(OrderStatus.CANCELED);
+        order.unUseCoupon();
+        order.getOrderItems().forEach(
+            orderItem -> itemRepository.increaseQuantity(orderItem.getItem().getItemId(),
+                orderItem.getQuantity())
+        );
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/payment/PaymentStatus.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/PaymentStatus.java
@@ -3,5 +3,6 @@ package com.prgrms.nabmart.domain.payment;
 public enum PaymentStatus {
     PENDING,
     SUCCESS,
-    CANCELED
+    CANCELED,
+    FAILED
 }

--- a/src/main/java/com/prgrms/nabmart/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.payment.controller;
 
+import com.prgrms.nabmart.domain.payment.service.PaymentClient;
 import com.prgrms.nabmart.domain.payment.service.PaymentService;
 import com.prgrms.nabmart.domain.payment.service.response.PaymentRequestResponse;
 import com.prgrms.nabmart.domain.payment.service.response.PaymentResponse;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final PaymentClient paymentClient;
 
     @PostMapping("/{orderId}")
     public ResponseEntity<PaymentRequestResponse> pay(
@@ -35,6 +37,8 @@ public class PaymentController {
         @RequestParam("amount") Integer amount,
         @LoginUser Long userId
     ) {
+        paymentClient.confirmPayment(uuid, paymentKey, amount);
+
         return ResponseEntity.ok(
             paymentService.processSuccessPayment(userId, uuid, paymentKey, amount));
     }

--- a/src/main/java/com/prgrms/nabmart/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/controller/PaymentController.java
@@ -36,6 +36,16 @@ public class PaymentController {
         @LoginUser Long userId
     ) {
         return ResponseEntity.ok(
-            paymentService.confirmPayment(userId, uuid, paymentKey, amount));
+            paymentService.processSuccessPayment(userId, uuid, paymentKey, amount));
+    }
+
+    @GetMapping("/toss/fail")
+    public ResponseEntity<PaymentResponse> payFail(
+        @RequestParam("orderId") String uuid,
+        @RequestParam("message") String errorMessage,
+        @LoginUser Long userId
+    ) {
+        return ResponseEntity.ok(
+            paymentService.processFailPayment(userId, uuid, errorMessage));
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/payment/service/PaymentClient.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/service/PaymentClient.java
@@ -1,0 +1,73 @@
+package com.prgrms.nabmart.domain.payment.service;
+
+import com.prgrms.nabmart.domain.payment.exception.PaymentFailException;
+import com.prgrms.nabmart.domain.payment.service.response.TossPaymentApiResponse;
+import com.prgrms.nabmart.global.infrastructure.ApiService;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentClient {
+
+    private final ApiService apiService;
+
+    @Value("${payment.toss.secret-key}")
+    private String secretKey;
+
+    @Value("${payment.toss.confirm-url}")
+    private String confirmUrl;
+
+    public void confirmPayment(final String uuid, final String paymentKey, final Integer amount) {
+        HttpHeaders httpHeaders = getHttpHeaders();
+        JSONObject params = getParams(uuid, paymentKey, amount);
+        TossPaymentApiResponse paymentApiResponse = requestPaymentApi(httpHeaders, params);
+
+        validatePaymentResult(paymentApiResponse);
+    }
+
+    private HttpHeaders getHttpHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBasicAuth(getEncodeAuth());
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        return httpHeaders;
+    }
+
+    private String getEncodeAuth() {
+        return new String(
+            Base64.getEncoder()
+                .encode((secretKey + ":").getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    private JSONObject getParams(String uuid, String paymentKey, Integer amount) {
+        JSONObject params = new JSONObject();
+        params.put("paymentKey", paymentKey);
+        params.put("orderId", uuid);
+        params.put("amount", amount);
+
+        return params;
+    }
+
+    private TossPaymentApiResponse requestPaymentApi(HttpHeaders httpHeaders, JSONObject params) {
+        return apiService.getResult(
+            new HttpEntity<>(params, httpHeaders),
+            confirmUrl,
+            TossPaymentApiResponse.class
+        );
+    }
+
+    private void validatePaymentResult(TossPaymentApiResponse paymentApiResponse) {
+        if (!paymentApiResponse.status().equals("DONE")) {
+            throw new PaymentFailException("결제가 실패되었습니다.");
+        }
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/payment/service/response/PaymentResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/payment/service/response/PaymentResponse.java
@@ -1,5 +1,5 @@
 package com.prgrms.nabmart.domain.payment.service.response;
 
-public record PaymentResponse(String status) {
+public record PaymentResponse(String status, String message) {
 
 }

--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -12,12 +12,14 @@ import com.prgrms.nabmart.domain.event.service.EventService;
 import com.prgrms.nabmart.domain.item.service.ItemService;
 import com.prgrms.nabmart.domain.item.service.LikeItemService;
 import com.prgrms.nabmart.domain.order.service.OrderService;
+import com.prgrms.nabmart.domain.payment.service.PaymentClient;
 import com.prgrms.nabmart.domain.payment.service.PaymentService;
 import com.prgrms.nabmart.domain.review.service.ReviewService;
 import com.prgrms.nabmart.domain.user.service.UserService;
 import com.prgrms.nabmart.global.auth.oauth.client.OAuthRestClient;
 import com.prgrms.nabmart.global.auth.service.RiderAuthenticationService;
 import com.prgrms.nabmart.global.auth.support.AuthFixture;
+import com.prgrms.nabmart.global.infrastructure.ApiService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,6 +75,12 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected PaymentService paymentService;
+
+    @MockBean
+    protected ApiService apiService;
+
+    @MockBean
+    protected PaymentClient paymentClient;
 
     @MockBean
     protected ReviewService reviewService;

--- a/src/test/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.item.repository;
 
+import static com.prgrms.nabmart.domain.item.support.ItemFixture.item;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.prgrms.nabmart.base.TestQueryDslConfig;
@@ -13,6 +14,7 @@ import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -147,6 +149,32 @@ class ItemRepositoryTest {
 
             // Then
             assertThat(items.size()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("increaseQuantity 메서드는")
+    class IncreaseQuantityTest {
+
+        @Test
+        @DisplayName("성공")
+        public void success() {
+            // Given
+            int increaseQuantity = 100;
+            Item item = item();
+            int originQuantity = item.getQuantity();
+
+            mainCategoryRepository.save(item.getMainCategory());
+            subCategoryRepository.save(item.getSubCategory());
+            itemRepository.save(item);
+
+            // When
+            itemRepository.increaseQuantity(item.getItemId(), increaseQuantity);
+
+            // Then
+            Optional<Item> findItem = itemRepository.findById(item.getItemId());
+            assertThat(findItem).isNotEmpty();
+            assertThat(findItem.get().getQuantity()).isEqualTo(originQuantity + increaseQuantity);
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/service/OrderServiceTest.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.prgrms.nabmart.domain.coupon.Coupon;
@@ -25,6 +27,8 @@ import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.exception.InvalidItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.order.OrderItem;
+import com.prgrms.nabmart.domain.order.OrderStatus;
 import com.prgrms.nabmart.domain.order.controller.request.CreateOrderRequest;
 import com.prgrms.nabmart.domain.order.controller.request.CreateOrderRequest.CreateOrderItemRequest;
 import com.prgrms.nabmart.domain.order.exception.NotFoundOrderException;
@@ -295,6 +299,27 @@ public class OrderServiceTest {
 
         // then
         assertThat(exception).isInstanceOf(InvalidCouponException.class);
+    }
+
+    @Nested
+    @DisplayName("cancelOrder 메서드 실행 시")
+    class CancelOrderTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Order order = pendingOrder(1L, user());
+            OrderItem orderItem = order.getOrderItems().get(0);
+
+            // when
+            orderService.cancelOrder(order);
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+            verify(itemRepository, times(1)).increaseQuantity(orderItem.getItem().getItemId(),
+                orderItem.getQuantity());
+        }
     }
 }
 

--- a/src/test/java/com/prgrms/nabmart/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/controller/PaymentControllerTest.java
@@ -26,13 +26,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@AutoConfigureRestDocs
-@WebMvcTest(PaymentController.class)
 public class PaymentControllerTest extends BaseControllerTest {
 
     @Value("${payment.toss.success-url}")
@@ -164,6 +160,4 @@ public class PaymentControllerTest extends BaseControllerTest {
                 ));
         }
     }
-
-
 }

--- a/src/test/java/com/prgrms/nabmart/domain/payment/service/PaymentClientTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/service/PaymentClientTest.java
@@ -1,0 +1,53 @@
+package com.prgrms.nabmart.domain.payment.service;
+
+import static com.prgrms.nabmart.domain.order.support.OrderFixture.payingOrder;
+import static com.prgrms.nabmart.domain.user.support.UserFixture.userWithUserId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.prgrms.nabmart.domain.order.Order;
+import com.prgrms.nabmart.domain.payment.exception.PaymentFailException;
+import com.prgrms.nabmart.domain.payment.service.response.TossPaymentApiResponse;
+import com.prgrms.nabmart.domain.user.User;
+import com.prgrms.nabmart.global.infrastructure.ApiService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentClientTest {
+
+    @InjectMocks
+    PaymentClient paymentClient;
+
+    @Mock
+    ApiService apiService;
+
+    @Test
+    @DisplayName("예외: 결제 상태가 DONE 이 아닌 경우, PaymentFailException 발생")
+    void throwExceptionWhenPayStatusIsNotDone() {
+        // given
+        User user = userWithUserId();
+        Order order = payingOrder(1L, user);
+
+        String mockPaymentKey = "mockPaymentKey";
+        int amount = order.getPrice();
+
+        when(apiService.getResult(any(), any(), any()))
+            .thenReturn(new TossPaymentApiResponse("간편결제", "FAIL"));
+
+        // when
+        Exception exception = catchException(
+            () -> paymentClient.confirmPayment(order.getUuid(), mockPaymentKey,
+                amount));
+
+        // then
+        assertThat(exception).isInstanceOf(PaymentFailException.class);
+    }
+
+}

--- a/src/test/java/com/prgrms/nabmart/domain/payment/support/PaymentDtoFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/support/PaymentDtoFixture.java
@@ -21,10 +21,10 @@ public class PaymentDtoFixture {
     }
 
     public static PaymentResponse paymentResponseWithSuccess() {
-        return new PaymentResponse("SUCCESS");
+        return new PaymentResponse("SUCCESS", null);
     }
 
     public static PaymentResponse paymentResponseWithFail() {
-        return new PaymentResponse("FAIL");
+        return new PaymentResponse("FAIL", "errorMessage");
     }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 결제가 실패할 경우를 처리했습니다.

### 📝 작업 요약
- 결제가 실패할 경우 `GET /api/v1/pays/toss/fail` 컨트롤러를 구현했습니다.
- 결제가 실패한 경우, 상품의 재고를 더하기 쿼리를 사용해 증가하는 로직을 구현했습니다.
- 트랜잭션 내부에 존재하던 외부 API 호출 로직을 컨트롤러 레이러로 분리하였습니다.

### 💡 관련 이슈
[NAYB-138](https://naybmart.atlassian.net/browse/NAYB-138?atlOrigin=eyJpIjoiYzFmZTg0YTc2MTE1NDU3NDhiYzQ4OWFhNTRmZWYzNjQiLCJwIjoiaiJ9)


[NAYB-138]: https://naybmart.atlassian.net/browse/NAYB-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ