### PR TITLE
[NAYB-151] fix: 라이더 배차 요청 잘못된 로직 수정

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.delivery;
 
+import com.prgrms.nabmart.domain.delivery.exception.AlreadyAssignedDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.UnauthorizedDeliveryException;
 import com.prgrms.nabmart.domain.order.Order;
@@ -18,6 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Version;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -99,7 +101,14 @@ public class Delivery extends BaseTimeEntity {
     }
 
     public void assignRider(Rider rider) {
+        checkAlreadyAssignedToRider();
         this.rider = rider;
+    }
+
+    private void checkAlreadyAssignedToRider() {
+        if (Objects.nonNull(this.rider)) {
+            throw new AlreadyAssignedDeliveryException("이미 배차 완료된 배달입니다.");
+        }
     }
 
     public void completeDelivery() {

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/Delivery.java
@@ -7,6 +7,8 @@ import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.global.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -42,6 +44,7 @@ public class Delivery extends BaseTimeEntity {
     @JoinColumn(name = "riderId")
     private Rider rider;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DeliveryStatus deliveryStatus;
 

--- a/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepository.java
@@ -21,7 +21,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     @Query(value = "select d from Delivery d"
         + " where d.deliveryStatus"
-        + " = com.prgrms.nabmart.domain.delivery.DeliveryStatus.ACCEPTING_ORDER")
+        + " = com.prgrms.nabmart.domain.delivery.DeliveryStatus.ACCEPTING_ORDER"
+        + " and d.rider is null")
     Page<Delivery> findWaitingDeliveries(Pageable pageable);
 
     @Query(value = "select d from Delivery d"

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepositoryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/repository/DeliveryRepositoryTest.java
@@ -88,6 +88,10 @@ class DeliveryRepositoryTest {
             int totalElements = 3;
             List<Order> orders = createAndSaveOrders(totalElements);
             List<Delivery> deliveries = createAndSaveDeliveries(orders);
+            List<Order> alreadyAssignedOrders = createAndSaveOrders(3);
+            List<Delivery> alreadyAssignedDeliveries
+                = createAndSaveDeliveries(alreadyAssignedOrders);
+            alreadyAssignedDeliveries.forEach(delivery -> delivery.assignRider(rider));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
             //when

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.BDDMockito.given;
 import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.DeliveryStatus;
 import com.prgrms.nabmart.domain.delivery.Rider;
+import com.prgrms.nabmart.domain.delivery.exception.AlreadyAssignedDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.InvalidDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.NotFoundDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.NotFoundRiderException;
@@ -400,6 +401,21 @@ class DeliveryServiceTest {
             //then
             assertThatThrownBy(() -> deliveryService.acceptDelivery(acceptDeliveryCommand))
                 .isInstanceOf(NotFoundDeliveryException.class);
+        }
+
+        @Test
+        @DisplayName("예외: 이미 배차 완료된 배달")
+        void throwExceptionWhenAlreadyAssignedDelivery() {
+            //given
+            given(riderRepository.findById(any())).willReturn(Optional.ofNullable(rider));
+            given(deliveryRepository.findByIdOptimistic(any())).willReturn(
+                Optional.ofNullable(delivery));
+            delivery.assignRider(rider);
+
+            //when
+            //then
+            assertThatThrownBy(() -> deliveryService.acceptDelivery(acceptDeliveryCommand))
+                .isInstanceOf(AlreadyAssignedDeliveryException.class);
         }
     }
 


### PR DESCRIPTION
### ⛏ 작업 사항
- 배차 요청 시 라이더와 배달의 연관관계를 추가하는 과정에서 검증 로직을 추가하였습니다.
- 배차 대기중인 배달 목록을 조회하면서 이미 배차 완료된 배달까지 함께 조회하는 쿼리를 수정하였습니다.
- 배달 엔티티가 사용하는 enum 필드에 `@Enumerated(STRING)`을 추가하였습니다.


### 📝 작업 요약
- `Delivery` `assignRider` 메서드에 검증 로직 추가
- `findWaitingDeliveries` jpql 수정
- `Delivery` `deliveryStatus` 필드에 `@Enumerated(STRING)` 추가


### 💡 관련 이슈
- [NAYB-151](https://naybmart.atlassian.net/browse/NAYB-151)



[NAYB-151]: https://naybmart.atlassian.net/browse/NAYB-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ