### PR TITLE
[NAYB-139] feat : 신상품 조회 시 Redis에서 가져온다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.item.controller;
 
+import com.prgrms.nabmart.domain.item.ItemSortType;
 import com.prgrms.nabmart.domain.item.controller.request.RegisterItemRequest;
 import com.prgrms.nabmart.domain.item.controller.request.UpdateItemRequest;
 import com.prgrms.nabmart.domain.item.service.ItemService;
@@ -71,8 +72,10 @@ public class ItemController {
     }
 
     @GetMapping("/new-items")
-    public ResponseEntity<FindNewItemsResponse> findNewItemsWithRedis() {
-        return ResponseEntity.ok(itemService.findNewItemsWithRedis());
+    public ResponseEntity<FindNewItemsResponse> findNewItemsWithRedis(
+        @RequestParam(defaultValue = "NEW") String sort
+    ) {
+        return ResponseEntity.ok(itemService.findNewItemsWithRedis(ItemSortType.valueOf(sort)));
     }
 
     @GetMapping("/hot")

--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
@@ -11,6 +11,7 @@ import com.prgrms.nabmart.domain.item.service.request.RegisterItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.UpdateItemCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindItemDetailResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindNewItemsResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +59,7 @@ public class ItemController {
     }
 
     @GetMapping("/new")
-    public ResponseEntity<FindItemsResponse> findNewItems(
+    public ResponseEntity<FindNewItemsResponse> findNewItems(
         @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastIdx,
         @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastItemId,
         @RequestParam int size,

--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
@@ -59,7 +59,7 @@ public class ItemController {
     }
 
     @GetMapping("/new")
-    public ResponseEntity<FindNewItemsResponse> findNewItems(
+    public ResponseEntity<FindItemsResponse> findNewItems(
         @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastIdx,
         @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastItemId,
         @RequestParam int size,
@@ -68,6 +68,11 @@ public class ItemController {
         FindNewItemsCommand findNewItemsCommand = FindNewItemsCommand.of(lastIdx, lastItemId, size,
             sort);
         return ResponseEntity.ok(itemService.findNewItems(findNewItemsCommand));
+    }
+
+    @GetMapping("/new-items")
+    public ResponseEntity<FindNewItemsResponse> findNewItemsWithRedis() {
+        return ResponseEntity.ok(itemService.findNewItemsWithRedis());
     }
 
     @GetMapping("/hot")

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
@@ -1,9 +1,12 @@
 package com.prgrms.nabmart.domain.item.service;
 
+import com.prgrms.nabmart.domain.item.ItemSortType;
 import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -21,13 +24,33 @@ public class ItemCacheService {
         redisTemplate.opsForList().rightPush(NEW_PRODUCTS_KEY, itemRedisDto);
     }
 
-    public List<ItemRedisDto> getNewItems() {
-        ListOperations<String, ItemRedisDto> items = redisTemplate.opsForList();
-        Long itemCount = items.size("new_products");
+    public List<ItemRedisDto> getNewItems(ItemSortType sortType) {
+        return getNewItemsSorted(sortType);
+    }
+
+    private List<ItemRedisDto> getNewItemsSorted(ItemSortType sortType) {
+        ListOperations<String, ItemRedisDto> listOperations = redisTemplate.opsForList();
+        Long itemCount = listOperations.size(NEW_PRODUCTS_KEY);
         if (itemCount == null || itemCount == 0) {
             return null;
         }
-        return items.range(NEW_PRODUCTS_KEY, 0, -1);
+
+        List<ItemRedisDto> items = listOperations.range(NEW_PRODUCTS_KEY, 0, -1);
+
+        return switch (sortType) {
+            case LOWEST_AMOUNT -> items.stream()
+                .sorted(Comparator.comparingInt(ItemRedisDto::price))
+                .collect(Collectors.toList());
+            case HIGHEST_AMOUNT -> items.stream()
+                .sorted(Comparator.comparingInt(ItemRedisDto::price).reversed())
+                .collect(Collectors.toList());
+            case DISCOUNT -> items.stream()
+                .sorted(Comparator.comparingInt(ItemRedisDto::discount).reversed())
+                .collect(Collectors.toList());
+            default -> items.stream()
+                .sorted(Comparator.comparingLong(ItemRedisDto::itemId).reversed())
+                .collect(Collectors.toList());
+        };
     }
 
     @Scheduled(cron = "0 0 * * * *")
@@ -35,16 +58,16 @@ public class ItemCacheService {
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minus(2, ChronoUnit.WEEKS);
 
         ListOperations<String, ItemRedisDto> items = redisTemplate.opsForList();
-        Long itemCount = items.size("new_products");
+        Long itemCount = items.size(NEW_PRODUCTS_KEY);
 
         if (itemCount == null || itemCount == 0) {
             return;
         }
 
         for (int i = 0; i < itemCount; i++) {
-            ItemRedisDto item = items.index("new_products", i);
+            ItemRedisDto item = items.index(NEW_PRODUCTS_KEY, i);
             if (item != null && item.createdAt().isBefore(twoWeeksAgo)) {
-                items.remove("new_products", 1, item);
+                items.remove(NEW_PRODUCTS_KEY, 1, item);
                 i--;
             }
         }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
@@ -1,0 +1,52 @@
+package com.prgrms.nabmart.domain.item.service;
+
+import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ItemCacheService {
+
+    private final RedisTemplate<String, ItemRedisDto> redisTemplate;
+    private static final String NEW_PRODUCTS_KEY = "new_products";
+
+    public void saveNewItem(ItemRedisDto itemRedisDto) {
+        redisTemplate.opsForList().rightPush(NEW_PRODUCTS_KEY, itemRedisDto);
+    }
+
+    public List<ItemRedisDto> getNewItems() {
+        ListOperations<String, ItemRedisDto> items = redisTemplate.opsForList();
+        Long itemCount = items.size("new_products");
+        if (itemCount == null || itemCount == 0) {
+            return null;
+        }
+        return items.range(NEW_PRODUCTS_KEY, 0, -1);
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void deleteOldProducts() {
+        LocalDateTime twoWeeksAgo = LocalDateTime.now().minus(2, ChronoUnit.WEEKS);
+
+        ListOperations<String, ItemRedisDto> items = redisTemplate.opsForList();
+        Long itemCount = items.size("new_products");
+
+        if (itemCount == null || itemCount == 0) {
+            return;
+        }
+
+        for (int i = 0; i < itemCount; i++) {
+            ItemRedisDto item = items.index("new_products", i);
+            if (item != null && item.createdAt().isBefore(twoWeeksAgo)) {
+                items.remove("new_products", 1, item);
+                i--;
+            }
+        }
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemCacheService.java
@@ -17,7 +17,7 @@ public class ItemCacheService {
     private final RedisTemplate<String, ItemRedisDto> redisTemplate;
     private static final String NEW_PRODUCTS_KEY = "new_products";
 
-    public void saveNewItem(ItemRedisDto itemRedisDto) {
+    public void saveNewItem(final ItemRedisDto itemRedisDto) {
         redisTemplate.opsForList().rightPush(NEW_PRODUCTS_KEY, itemRedisDto);
     }
 

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
@@ -43,6 +43,9 @@ public class ItemService {
     private final ItemCacheService itemCacheService;
     private final RedisCacheService redisCacheService;
 
+    private static final String REVIEW_COUNT_CACHE_KEY = "reviewCount:Item:";
+    private static final String AVERAGE_RATE_CACHE_KEY = "averageRating:Item:";
+
     @Transactional
     public Long saveItem(RegisterItemCommand registerItemCommand) {
         Long mainCategoryId = registerItemCommand.mainCategoryId();
@@ -114,7 +117,8 @@ public class ItemService {
             item.name(),
             item.price(),
             item.discount(),
-            redisCacheService.getTotalNumberOfReviewsByItemId(item.itemId(), "reviewCount_Item_" + item.itemId())
+            redisCacheService.getTotalNumberOfReviewsByItemId(item.itemId(), REVIEW_COUNT_CACHE_KEY + item.itemId()),
+            redisCacheService.getAverageRatingByItemId(item.itemId(), AVERAGE_RATE_CACHE_KEY + item.itemId())
         )).toList();
 
         return FindNewItemsResponse.from(sortNewItems(items, sortType));

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
@@ -105,8 +105,8 @@ public class ItemService {
     }
 
     @Transactional(readOnly = true)
-    public FindNewItemsResponse findNewItemsWithRedis() {
-        List<ItemRedisDto> itemRedisDtos = itemCacheService.getNewItems();
+    public FindNewItemsResponse findNewItemsWithRedis(ItemSortType sortType) {
+        List<ItemRedisDto> itemRedisDtos = itemCacheService.getNewItems(sortType);
 
         List<FindNewItemResponse> items = itemRedisDtos.stream().map(item -> FindNewItemResponse.of(
             item.itemId(),

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
@@ -97,7 +97,15 @@ public class ItemService {
     }
 
     @Transactional(readOnly = true)
-    public FindNewItemsResponse findNewItems(FindNewItemsCommand findNewItemsCommand) {
+    public FindItemsResponse findNewItems(FindNewItemsCommand findNewItemsCommand) {
+        return FindItemsResponse.from(
+            itemRepository.findNewItemsOrderBy(findNewItemsCommand.lastIdx(),
+                findNewItemsCommand.lastItemId(), findNewItemsCommand.sortType(),
+                findNewItemsCommand.pageRequest()));
+    }
+
+    @Transactional(readOnly = true)
+    public FindNewItemsResponse findNewItemsWithRedis() {
         List<ItemRedisDto> itemRedisDtos = itemCacheService.getNewItems();
 
         List<FindNewItemResponse> items = itemRedisDtos.stream().map(item -> FindNewItemResponse.of(

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
@@ -17,6 +17,7 @@ import com.prgrms.nabmart.domain.item.service.request.RegisterItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.UpdateItemCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindItemDetailResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
 import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class ItemService {
     private final OrderItemRepository orderItemRepository;
     private final MainCategoryRepository mainCategoryRepository;
     private final SubCategoryRepository subCategoryRepository;
-    private static final int NEW_PRODUCT_REFERENCE_WEEK = 2;
+    private final ItemCacheService itemCacheService;
 
     @Transactional
     public Long saveItem(RegisterItemCommand registerItemCommand) {
@@ -55,6 +56,7 @@ public class ItemService {
             .build();
 
         Item savedItem = itemRepository.save(item);
+        itemCacheService.saveNewItem(ItemRedisDto.from(savedItem));
         return savedItem.getItemId();
     }
 

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
@@ -1,0 +1,24 @@
+package com.prgrms.nabmart.domain.item.service.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record FindNewItemsResponse(List<FindNewItemResponse> items) {
+
+    public static FindNewItemsResponse from(List<FindNewItemResponse> items) {
+        List<FindNewItemResponse> findNewItemResponses = items.stream()
+            .map(item -> FindNewItemResponse.of(item.itemId, item.name, item.price, item.discount,
+                item.reviewCount))
+            .collect(Collectors.toList());
+        return new FindNewItemsResponse(findNewItemResponses);
+    }
+
+    public record FindNewItemResponse(Long itemId, String name, int price, int discount,
+                                      Long reviewCount) {
+
+        public static FindNewItemResponse of(Long itemId, String name, int price, int discount,
+            Long reviewCount) {
+            return new FindNewItemResponse(itemId, name, price, discount, reviewCount);
+        }
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
@@ -8,17 +8,17 @@ public record FindNewItemsResponse(List<FindNewItemResponse> items) {
     public static FindNewItemsResponse from(List<FindNewItemResponse> items) {
         List<FindNewItemResponse> findNewItemResponses = items.stream()
             .map(item -> FindNewItemResponse.of(item.itemId, item.name, item.price, item.discount,
-                item.reviewCount))
+                item.reviewCount, item.rate))
             .collect(Collectors.toList());
         return new FindNewItemsResponse(findNewItemResponses);
     }
 
     public record FindNewItemResponse(Long itemId, String name, int price, int discount,
-                                      Long reviewCount) {
+                                      Long reviewCount, double rate) {
 
         public static FindNewItemResponse of(Long itemId, String name, int price, int discount,
-            Long reviewCount) {
-            return new FindNewItemResponse(itemId, name, price, discount, reviewCount);
+            Long reviewCount, double rate) {
+            return new FindNewItemResponse(itemId, name, price, discount, reviewCount, rate);
         }
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/FindNewItemsResponse.java
@@ -16,8 +16,8 @@ public record FindNewItemsResponse(List<FindNewItemResponse> items) {
     public record FindNewItemResponse(Long itemId, String name, int price, int discount,
                                       Long reviewCount, double rate) {
 
-        public static FindNewItemResponse of(Long itemId, String name, int price, int discount,
-            Long reviewCount, double rate) {
+        public static FindNewItemResponse of(final Long itemId, final String name, final int price, final int discount,
+            final Long reviewCount, final double rate) {
             return new FindNewItemResponse(itemId, name, price, discount, reviewCount, rate);
         }
     }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/ItemRedisDto.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/ItemRedisDto.java
@@ -1,10 +1,17 @@
 package com.prgrms.nabmart.domain.item.service.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.prgrms.nabmart.domain.item.Item;
 import java.time.LocalDateTime;
 
 public record ItemRedisDto(Long itemId, String name, int price, int discount,
-                           LocalDateTime createdAt) {
+                           @JsonSerialize(using = LocalDateTimeSerializer.class)
+                           @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                           LocalDateTime createdAt
+) {
 
     public static ItemRedisDto from(final Item item) {
         return new ItemRedisDto(

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/response/ItemRedisDto.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/response/ItemRedisDto.java
@@ -1,0 +1,15 @@
+package com.prgrms.nabmart.domain.item.service.response;
+
+import com.prgrms.nabmart.domain.item.Item;
+import java.time.LocalDateTime;
+
+public record ItemRedisDto(Long itemId, String name, int price, int discount,
+                           LocalDateTime createdAt) {
+
+    public static ItemRedisDto from(final Item item) {
+        return new ItemRedisDto(
+            item.getItemId(), item.getName(), item.getPrice(), item.getDiscount(),
+            item.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/config/RedisConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.global.config;
 
+import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -26,10 +28,30 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Long> stringToLongRedisTemplate() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setValueSerializer(
+            new GenericToStringSerializer<>(Long.class));
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Double> stringToDoubleRedisTemplate() {
+        RedisTemplate<String, Double> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(
+            new GenericToStringSerializer<>(Double.class));
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, ItemRedisDto> itemRedisDtoRedisTemplate() {
+        RedisTemplate<String, ItemRedisDto> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ItemRedisDto.class));
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
     }

--- a/src/main/java/com/prgrms/nabmart/global/config/RedisConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/RedisConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableCaching
@@ -26,11 +26,10 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Long> redisTemplate() {
-        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(
-            new GenericToStringSerializer<>(Long.class)); // Long 값을 다루므로 설정 변경
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
     }

--- a/src/test/java/com/prgrms/nabmart/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/controller/ItemControllerTest.java
@@ -25,6 +25,7 @@ import com.prgrms.nabmart.domain.item.controller.request.UpdateItemRequest;
 import com.prgrms.nabmart.domain.item.service.request.FindItemsByCategoryCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindItemDetailResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindNewItemsResponse;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -364,6 +365,57 @@ class ItemControllerTest extends BaseControllerTest {
                         parameterWithName("itemId").description("상품 ID")
                     ))
                 );
+        }
+    }
+
+    @Nested
+    @DisplayName("신상품 조회 Api with redis")
+    class FindNewItemsWithRedis {
+
+        FindNewItemsResponse findNewItemsResponse = ItemFixture.findNewItemsResponse();
+
+        @Test
+        @DisplayName("성공")
+        public void findNewItemsWithRedis() throws Exception {
+            // Given
+            given(itemService.findNewItemsWithRedis(any())).willReturn(findNewItemsResponse);
+
+
+            // When
+            ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/items/new-items")
+                    .queryParam("lastIdx", "-1")
+                    .queryParam("lastItemId", "-1")
+                    .queryParam("size", "3")
+                    .queryParam("sort", "NEW")
+                    .accept(MediaType.APPLICATION_JSON));
+
+            // Then
+            resultActions.andExpect(status().isOk())
+                .andDo(document("Find New Items with Redis",
+                    queryParameters(
+                        parameterWithName("lastIdx").description("마지막에 조회한 아이템의 특성값"),
+                        parameterWithName("lastItemId").description("마지막에 조회한 아이템 ID"),
+                        parameterWithName("size").description("조회할 아이템 수"),
+                        parameterWithName("sort").description("정렬 기준명")
+                    ),
+                    responseFields(
+                        fieldWithPath("items").type(ARRAY)
+                            .description("List of items"),
+                        fieldWithPath("items[].itemId").type(NUMBER)
+                            .description("상품 ID"),
+                        fieldWithPath("items[].name").type(STRING)
+                            .description("상품 이름"),
+                        fieldWithPath("items[].price").type(NUMBER)
+                            .description("상품 가격"),
+                        fieldWithPath("items[].discount").type(NUMBER)
+                            .description("상품 할인"),
+                        fieldWithPath("items[].reviewCount").type(NUMBER)
+                            .description("리뷰 수"),
+                        fieldWithPath("items[].rate").type(NUMBER)
+                            .description("평점")
+                    )
+                ));
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/ItemCacheServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/ItemCacheServiceTest.java
@@ -1,0 +1,94 @@
+package com.prgrms.nabmart.domain.item.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.prgrms.nabmart.base.RedisTestContainerConfig;
+import com.prgrms.nabmart.domain.category.MainCategory;
+import com.prgrms.nabmart.domain.category.SubCategory;
+import com.prgrms.nabmart.domain.category.fixture.CategoryFixture;
+import com.prgrms.nabmart.domain.item.Item;
+import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
+import com.prgrms.nabmart.domain.item.support.ItemFixture;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+class ItemCacheServiceTest extends RedisTestContainerConfig {
+
+    @Autowired
+    private ItemCacheService itemCacheService;
+
+    @Autowired
+    private RedisTemplate<String, ItemRedisDto> redisTemplate;
+
+    private static final String NEW_PRODUCTS_KEY = "new_products";
+    Item item;
+    MainCategory mainCategory;
+    SubCategory subCategory;
+
+    @BeforeEach
+    void setUp() {
+        mainCategory = CategoryFixture.mainCategory();
+        subCategory = CategoryFixture.subCategory(mainCategory);
+        item = ItemFixture.item(mainCategory, subCategory);
+    }
+
+    @AfterEach
+    public void cleanupRedis() {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.flushDb();
+            return null;
+        });
+    }
+
+    @Nested
+    @DisplayName("새롭게 등록된 상품을 Redis에도 등록한다.")
+    class SaveItemRedisTest {
+
+        @Test
+        @DisplayName("성공")
+        void saveNewItem() {
+            // Given
+            ItemRedisDto itemRedisDto = ItemRedisDto.from(item);
+
+            // When
+            itemCacheService.saveNewItem(itemRedisDto);
+
+            // Then
+            assertThat(redisTemplate.opsForList().size(NEW_PRODUCTS_KEY)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Redis에서 신상품을 조회한다.")
+    class getNewItemsTest {
+
+        @Test
+        @DisplayName("성공")
+        void getNewItems() {
+            // Given
+            ItemRedisDto itemRedisDto = ItemRedisDto.from(item);
+            List<ItemRedisDto> expectedItems = List.of(itemRedisDto);
+
+            itemCacheService.saveNewItem(itemRedisDto);
+
+            // When
+            List<ItemRedisDto> result = itemCacheService.getNewItems();
+
+            // Then
+            assertThat(result).isEqualTo(expectedItems);
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
@@ -24,6 +24,7 @@ import com.prgrms.nabmart.domain.item.service.request.RegisterItemCommand;
 import com.prgrms.nabmart.domain.item.service.request.UpdateItemCommand;
 import com.prgrms.nabmart.domain.item.service.response.FindItemDetailResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
+import com.prgrms.nabmart.domain.item.service.response.ItemRedisDto;
 import com.prgrms.nabmart.domain.item.support.ItemFixture;
 import com.prgrms.nabmart.domain.order.repository.OrderItemRepository;
 import java.util.Comparator;
@@ -53,6 +54,9 @@ class ItemServiceTest {
     @Mock
     private OrderItemRepository orderItemRepository;
 
+    @Mock
+    private ItemCacheService itemCacheService;
+
     @InjectMocks
     private ItemService itemService;
 
@@ -80,6 +84,7 @@ class ItemServiceTest {
             verify(mainCategoryRepository, times(1)).findById(anyLong());
             verify(subCategoryRepository, times(1)).findById(anyLong());
             verify(itemRepository, times(1)).save(any());
+            verify(itemCacheService, times(1)).saveNewItem(any(ItemRedisDto.class));
         }
     }
 

--- a/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/support/ItemFixture.java
@@ -21,6 +21,7 @@ import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindItemsResponse.FindItemResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse.FindLikeItemResponse;
+import com.prgrms.nabmart.domain.item.service.response.FindNewItemsResponse;
 import com.prgrms.nabmart.domain.user.User;
 import java.util.List;
 import lombok.AccessLevel;
@@ -151,4 +152,8 @@ public final class ItemFixture {
         );
     }
 
+    public static FindNewItemsResponse findNewItemsResponse() {
+        return new FindNewItemsResponse(List.of(
+            new FindNewItemsResponse.FindNewItemResponse(1L, NAME, PRICE, DISCOUNT, 0L, RATE)));
+    }
 }


### PR DESCRIPTION
### ⛏ 작업 사항
- 새 상품을 등록할 시 Redis에도 등록된다.
- 신상품 조회 시 Redis에서 가져온다.
- 매일 자정 신상품이 아닌 상품은 redis에서 삭제된다.

### 📝 작업 요약
- 기존 신상품 조회 API를 삭제하는 것이 아쉬워서 우선 `~/items/new-items`이라는 새로운 API를 만들었습니다.
- 신상품 조회를 위한 controller, service 메서드 추가
- `ItemCacheService`에 신상품 등록, 조회, 삭제 메서드 추가
- 테스트 코드 작성

### 💡 관련 이슈
[NAYB-139](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?selectedIssue=NAYB-139)


[NAYB-139]: https://naybmart.atlassian.net/browse/NAYB-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ