### PR TITLE
[NAYB-153] feat: api 권한 설정

### DIFF
--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
@@ -46,6 +46,9 @@ public class RestTemplateOAuthClient implements OAuthRestClient {
         Map<String, Object> response = sendPostApiRequest(unlinkHttpMessage);
         log.info("회원의 연결이 종료되었습니다. 회원 ID={}", response);
         oAuthHttpMessageProvider.checkSuccessUnlinkRequest(response);
+        authorizedClientService.removeAuthorizedClient(
+            userDetailResponse.provider(),
+            userDetailResponse.provider());
     }
 
     @Override

--- a/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
@@ -1,8 +1,13 @@
 package com.prgrms.nabmart.global.config;
 
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
 import com.prgrms.nabmart.global.auth.jwt.JwtAuthenticationProvider;
 import com.prgrms.nabmart.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.nabmart.global.auth.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -17,6 +22,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -37,7 +43,11 @@ public class WebSecurityConfig {
         JwtAuthenticationProvider jwtAuthenticationProvider) throws Exception {
         http
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll())
+                .requestMatchers(requestPermitAll()).permitAll()
+                .requestMatchers(requestHasRoleUser()).hasRole("USER")
+                .requestMatchers(requestHasRoleRider()).hasRole("RIDER")
+                .requestMatchers(requestHasRoleAdmin()).hasRole("ADMIN")
+                .anyRequest().denyAll())
             .csrf(AbstractHttpConfigurer::disable)
             .headers(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
@@ -51,6 +61,48 @@ public class WebSecurityConfig {
             .addFilterAfter(new JwtAuthenticationFilter(jwtAuthenticationProvider),
                 SecurityContextHolderFilter.class);
         return http.build();
+    }
+
+    private RequestMatcher[] requestPermitAll() {
+        List<RequestMatcher> requestMatchers = List.of(
+            antMatcher(POST, "/oauth2/authorization/**"),
+            antMatcher(POST, "/api/v1/riders/**"),
+            antMatcher(GET, "/api/v1/categories/**"),
+            antMatcher(GET, "/api/v1/items/**"),
+            antMatcher(GET, "/api/v1/events/**"));
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private RequestMatcher[] requestHasRoleUser() {
+        List<RequestMatcher> requestMatchers = List.of(
+            antMatcher("/api/v1/users/me"),
+            antMatcher("/api/v1/cart-items/**"),
+            antMatcher("/api/v1/my-cart-items"),
+            antMatcher("/api/v1/likes/**"),
+            antMatcher("/api/v1/reviews/**"),
+            antMatcher("/api/v1/users/my-reviews"),
+            antMatcher("/api/v1/orders/**"),
+            antMatcher("/api/v1/pays/**"),
+            antMatcher("/api/v1/coupons/**")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private RequestMatcher[] requestHasRoleRider() {
+        List<RequestMatcher> requestMatchers = List.of(
+            antMatcher("/api/v1/deliveries/**")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private RequestMatcher[] requestHasRoleAdmin() {
+        List<RequestMatcher> requestMatchers = List.of(
+            antMatcher("/api/v1/main-categories/**"),
+            antMatcher("/api/v1/sub-categories/**"),
+            antMatcher("/api/v1/items/**"),
+            antMatcher("/api/v1/events/**"),
+            antMatcher(POST, "/api/v1/coupons"));
+        return requestMatchers.toArray(RequestMatcher[]::new);
     }
 
     @Bean

--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -16,6 +16,8 @@ import com.prgrms.nabmart.domain.payment.service.PaymentClient;
 import com.prgrms.nabmart.domain.payment.service.PaymentService;
 import com.prgrms.nabmart.domain.review.service.ReviewService;
 import com.prgrms.nabmart.domain.user.service.UserService;
+import com.prgrms.nabmart.global.auth.jwt.JwtAuthenticationProvider;
+import com.prgrms.nabmart.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.prgrms.nabmart.global.auth.oauth.client.OAuthRestClient;
 import com.prgrms.nabmart.global.auth.service.RiderAuthenticationService;
 import com.prgrms.nabmart.global.auth.support.AuthFixture;
@@ -31,8 +33,6 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -107,21 +107,22 @@ public abstract class BaseControllerTest {
 
     @BeforeEach
     void authenticationSetUp() {
-        Authentication authentication = AuthFixture.usernamePasswordAuthenticationToken();
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
         accessToken = AuthFixture.accessToken();
     }
 
     @BeforeEach
-    void restDocsSetUp(
+    void mockMvcSetUp(
         final WebApplicationContext context,
         final RestDocumentationContextProvider provider) {
+        JwtAuthenticationProvider jwtAuthenticationProvider
+            = new JwtAuthenticationProvider(AuthFixture.tokenProvider());
+
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-            .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
             .alwaysDo(print())
             .alwaysDo(restDocs)
             .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .addFilter(new JwtAuthenticationFilter(jwtAuthenticationProvider))
+            .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
             .build();
     }
 

--- a/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/cart/controller/CartItemControllerTest.java
@@ -45,7 +45,8 @@ class CartItemControllerTest extends BaseControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(post("/api/v1/cart-items")
                 .content(objectMapper.writeValueAsString(registerCartItemCommand))
-                .contentType(MediaType.APPLICATION_JSON));
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, accessToken));
 
             // then
             resultActions
@@ -146,7 +147,8 @@ class CartItemControllerTest extends BaseControllerTest {
                 // when
                 ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/my-cart-items")
-                        .contentType(MediaType.APPLICATION_JSON));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION, accessToken));
 
                 // then
                 resultActions.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/nabmart/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/coupon/controller/CouponControllerTest.java
@@ -95,7 +95,8 @@ class CouponControllerTest extends BaseControllerTest {
             ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/my-coupons/{couponId}", couponId)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(registerUserCouponCommand)));
+                    .content(objectMapper.writeValueAsString(registerUserCouponCommand))
+                    .header(AUTHORIZATION, accessToken));
 
             // Then
             resultActions
@@ -166,7 +167,8 @@ class CouponControllerTest extends BaseControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(get("/api/v1/my-coupons")
-                .contentType(MediaType.APPLICATION_JSON));
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, accessToken));
 
             // Then
             resultActions.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/controller/DeliveryControllerTest.java
@@ -207,7 +207,8 @@ class DeliveryControllerTest extends BaseControllerTest {
             ResultActions resultActions = mockMvc.perform(get("/api/v1/deliveries/waiting")
                 .param("page", String.valueOf(page))
                 .param("size", String.valueOf(size))
-                .accept(MediaType.APPLICATION_JSON));
+                .accept(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, accessToken));
 
             //then
             resultActions.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/nabmart/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/controller/OrderControllerTest.java
@@ -61,7 +61,8 @@ public class OrderControllerTest extends BaseControllerTest {
             // when
             ResultActions result = mockMvc.perform(
                 get("/api/v1/orders/{orderId}", order.getOrderId())
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result
@@ -100,7 +101,8 @@ public class OrderControllerTest extends BaseControllerTest {
             // when
             ResultActions result = mockMvc.perform(
                 get("/api/v1/orders?page={page}", 1)
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result
@@ -148,7 +150,8 @@ public class OrderControllerTest extends BaseControllerTest {
             ResultActions result = mockMvc.perform(
                 post("/api/v1/orders")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(createOrderRequest)));
+                    .content(objectMapper.writeValueAsString(createOrderRequest))
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result
@@ -183,7 +186,8 @@ public class OrderControllerTest extends BaseControllerTest {
             ResultActions result = mockMvc.perform(
                 post("/api/v1/orders/{orderId}/apply-coupon", order.getOrderId())
                     .param("couponId", String.valueOf(1L))
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result

--- a/src/test/java/com/prgrms/nabmart/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/payment/controller/PaymentControllerTest.java
@@ -59,7 +59,8 @@ public class PaymentControllerTest extends BaseControllerTest {
             // when
             ResultActions result = mockMvc.perform(
                 post("/api/v1/pays/{orderId}", order.getOrderId())
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result
@@ -104,7 +105,8 @@ public class PaymentControllerTest extends BaseControllerTest {
                     .queryParam("orderId", order.getUuid())
                     .queryParam("paymentKey", paymentKey)
                     .queryParam("amount", String.valueOf(order.getPrice()))
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result
@@ -143,7 +145,8 @@ public class PaymentControllerTest extends BaseControllerTest {
                 get("/api/v1/pays/toss/fail")
                     .queryParam("orderId", order.getUuid())
                     .queryParam("message", errorMessage)
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             result

--- a/src/test/java/com/prgrms/nabmart/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/review/controller/ReviewControllerTest.java
@@ -48,7 +48,8 @@ class ReviewControllerTest extends BaseControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(post("/api/v1/reviews")
                 .content(objectMapper.writeValueAsString(registerReviewCommand))
-                .contentType(MediaType.APPLICATION_JSON));
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, accessToken));
 
             // then
             resultActions
@@ -142,7 +143,8 @@ class ReviewControllerTest extends BaseControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/users/my-reviews")
-                    .contentType(MediaType.APPLICATION_JSON));
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken));
 
             // then
             resultActions.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/nabmart/global/auth/support/AuthFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/support/AuthFixture.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -23,7 +24,6 @@ public final class AuthFixture {
     private static final String CLIENT_SECRET = "thisIsClientSecretForTestNotARealSecretSoDontWorry";
     private static final int EXPIRY_SECONDS = 60;
     private static final Long USER_ID = 1L;
-    private static final String TOKEN = "token";
     private static final String RIDER_USERNAME = "rider123";
     private static final String RIDER_PASSWORD = "rider123";
     private static final String RIDER_ADDRESS = "address";
@@ -33,8 +33,11 @@ public final class AuthFixture {
     }
 
     public static Authentication usernamePasswordAuthenticationToken() {
-        JwtAuthentication authentication = new JwtAuthentication(USER_ID, TOKEN);
-        return new UsernamePasswordAuthenticationToken(authentication, null);
+        JwtAuthentication authentication = new JwtAuthentication(USER_ID, accessToken());
+        return new UsernamePasswordAuthenticationToken(
+            authentication,
+            null,
+            UserRole.ROLE_USER.getAuthorities().stream().map(SimpleGrantedAuthority::new).toList());
     }
 
     public static RegisterUserResponse registerUserResponse() {


### PR DESCRIPTION
### ⛏ 작업 사항
- api 별 권한 설정을 추가했습니다. 추후 새로운 api가 추가되는 경우 알려주세요.
- `@WebMvcTest` 설정이 일부 변경되었습니다. 기존에 셋업 메서드를 통해서 인증 객체를 미리 설정하는 것에서 JWT필터를 적용하여 직접 accessToken을 헤더에 추가하는 방식으로 변경하였습니다.
  - 기존 mockMvc 테스트에는 모두 적용시켜두었습니다. 새롭게 컨트롤러 테스트를 수행할 때, `@LoginUser`를 사용한다면 `mockMvc.perform(~).header(AUTHORIZATION, accessToken)`을 추가해주세요. `BaseControllerTest`에 필드에 `Authorization`과 `accessToken`을 추가해두었기 때문에 앞에 작성한 코드처럼 작성하시면 됩니다.
- 회원 연동 해제 로직에서 데이터베이스의 oauth2 데이터가 삭제되지 않는 문제를 발견하여 로직 일부를 수정하였습니다.


### 📝 작업 요약
- `BaseControllerTest` 인증 객체 설정 제거, `JwtAuthenticationFilter` 적용 및 자식 테스트 클래스에 반영
- `RestTemplateOAuthClient` 회원 연동 해제 시 oauth2 데이터 삭제 메서드 호출 추가
- `WebSecurityConfig` 유저 role에 따라 api 권한 검증 추가


### 💡 관련 이슈
- [NAYB-153](https://naybmart.atlassian.net/browse/NAYB-153)


[NAYB-153]: https://naybmart.atlassian.net/browse/NAYB-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ