### PR TITLE
[NAYB-141] refactor: 카테고리별 무한스크롤 조회 -> querydsl 변경

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/item/ItemSortType.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/ItemSortType.java
@@ -22,4 +22,8 @@ public enum ItemSortType {
             .findAny()
             .orElseThrow(() -> new NotFoundItemSortTypeException("요청하신 정렬기준은 존재하지 않습니다."));
     }
+
+    public boolean isPopular() {
+        return this == POPULAR;
+    }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/controller/ItemController.java
@@ -38,15 +38,15 @@ public class ItemController {
 
     @GetMapping
     public ResponseEntity<FindItemsResponse> findItemsByCategory(
+        @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastItemId,
         @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long lastIdx,
-        @RequestParam(defaultValue = DEFAULT_PREVIOUS_ID) Long option,
         @RequestParam int size,
         @RequestParam String main,
         @RequestParam(required = false) String sub,
         @RequestParam String sort) {
 
         FindItemsByCategoryCommand findItemsByCategoryCommand = FindItemsByCategoryCommand.of(
-            lastIdx, option, main, sub, size, sort);
+            lastItemId, lastIdx, main, sub, size, sort);
         FindItemsResponse findItemsResponse = itemService.findItemsByCategory(
             findItemsByCategoryCommand);
         return ResponseEntity.ok(findItemsResponse);

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
@@ -28,43 +28,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
     @Query("select i from Item i where i.itemId in ?1")
     List<Item> findByItemIdIn(Collection<Long> itemIds);
 
-    //== 대카테고리 품목 조회 ==//
-    // 대카테고리 전체 조회 - 최신 등록 순
-    List<Item> findByItemIdLessThanAndMainCategoryOrderByItemIdDesc(Long itemId,
-        MainCategory mainCategory, Pageable pageable);
-
-    // 대카테고리 전체 조회 - 할인율 높은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND (i.discount < :discount OR (i.discount = :discount AND i.itemId < :itemId)) "
-        + "ORDER BY i.discount DESC, i.itemId DESC")
-    List<Item> findByMainCategoryAndDiscountDesc(@Param("itemId") Long itemId,
-        @Param("discount") int discount, @Param("mainCategory") MainCategory mainCategory,
-        Pageable pageable);
-
-    // 대카테고리 전체 조회 - 금액 높은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND (i.price < :price OR (i.price = :price AND i.itemId < :itemId)) "
-        + "ORDER BY i.price DESC, i.itemId DESC")
-    List<Item> findByMainCategoryAndPriceDesc(@Param("itemId") Long itemId,
-        @Param("price") int price, @Param("mainCategory") MainCategory mainCategory,
-        Pageable pageable);
-
-    // 대카테고리 전체 조회 - 금액 낮은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND (i.price > :price OR (i.price = :price AND i.itemId < :itemId)) "
-        + "ORDER BY i.price ASC, i.itemId DESC")
-    List<Item> findByByMainCategoryAndPriceAsc(@Param("itemId") Long itemId,
-        @Param("price") int price, @Param("mainCategory") MainCategory mainCategory,
-        Pageable pageable);
-
-    // 대카테고리 전체 조회 - 주문 많은 순
-    @Query("SELECT i " + "FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i "
-        + "WHERE i.mainCategory = :mainCategory " + "AND i.itemId < :itemId " + "GROUP BY i "
-        + "HAVING (SUM(oi.quantity) <= :totalOrderedQuantity) "
-        + "ORDER BY SUM(oi.quantity) DESC, i.itemId DESC")
-    List<Item> findByOrderedQuantityAndMainCategory(@Param("itemId") Long itemId,
-        @Param("totalOrderedQuantity") Long totalOrderedQuantity,
-        @Param("mainCategory") MainCategory mainCategory, Pageable pageable);
 
     //== 소카테고리 품목 조회 ==//
     // 소카테고리 전체 조회 - 최신 등록 순

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepository.java
@@ -1,14 +1,10 @@
 package com.prgrms.nabmart.domain.item.repository;
 
-import com.prgrms.nabmart.domain.category.MainCategory;
-import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.Item;
 import jakarta.persistence.LockModeType;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -27,115 +23,4 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
 
     @Query("select i from Item i where i.itemId in ?1")
     List<Item> findByItemIdIn(Collection<Long> itemIds);
-
-
-    //== 소카테고리 품목 조회 ==//
-    // 소카테고리 전체 조회 - 최신 등록 순
-    List<Item> findByItemIdLessThanAndMainCategoryAndSubCategoryOrderByItemIdDesc(Long itemId,
-        MainCategory mainCategory, SubCategory subCategory, Pageable pageable);
-
-    // 소카테고리 전체 조회 - 할인율 높은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND i.subCategory = :subCategory "
-        + "AND (i.discount < :discount OR (i.discount = :discount AND i.itemId < :itemId)) "
-        + "ORDER BY i.discount DESC, i.itemId DESC")
-    List<Item> findBySubCategoryAndDiscountDesc(@Param("itemId") Long itemId,
-        @Param("discount") int discount, @Param("mainCategory") MainCategory mainCategory,
-        @Param("subCategory") SubCategory subCategory, Pageable pageable);
-
-    // 소카테고리 전체 조회 - 금액 높은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND i.subCategory = :subCategory "
-        + "AND (i.price < :price OR (i.price = :price AND i.itemId < :itemId)) "
-        + "ORDER BY i.price DESC, i.itemId DESC")
-    List<Item> findBySubCategoryAndPriceDesc(@Param("itemId") Long itemId,
-        @Param("price") int price, @Param("mainCategory") MainCategory mainCategory,
-        @Param("subCategory") SubCategory subCategory, Pageable pageable);
-
-    // 소카테고리 전체 조회 - 금액 낮은 순
-    @Query("SELECT i " + "FROM Item i " + "WHERE i.mainCategory = :mainCategory "
-        + "AND i.subCategory = :subCategory "
-        + "AND (i.price > :price OR (i.price = :price AND i.itemId < :itemId)) "
-        + "ORDER BY i.price ASC, i.itemId DESC")
-    List<Item> findBySubCategoryAndPriceAsc(@Param("itemId") Long itemId, @Param("price") int price,
-        @Param("mainCategory") MainCategory mainCategory,
-        @Param("subCategory") SubCategory subCategory, Pageable pageable);
-
-    // 소카테고리 전체 조회 - 주문 많은 순
-    @Query("SELECT i " + "FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i "
-        + "WHERE i.mainCategory = :mainCategory " + "AND i.subCategory = :subCategory "
-        + "AND i.itemId < :itemId " + "GROUP BY i "
-        + "HAVING (SUM(oi.quantity) <= :totalOrderedQuantity) "
-        + "ORDER BY SUM(oi.quantity) DESC, i.itemId DESC")
-    List<Item> findByOrderedQuantityAndMainCategoryAndSubCategory(@Param("itemId") Long itemId,
-        @Param("totalOrderedQuantity") Long totalOrderedQuantity,
-        @Param("mainCategory") MainCategory mainCategory,
-        @Param("subCategory") SubCategory subCategory, Pageable pageable);
-
-    //== 신상품 조회 ==//
-    // 신상품 - 주문 많은 순
-    @Query("SELECT i " + "FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i "
-        + "WHERE i.createdAt > :createdAt " + "GROUP BY i "
-        + "HAVING SUM(oi.quantity) < :totalOrderedQuantity OR SUM(oi.quantity) = NULL "
-        + "ORDER BY SUM(oi.quantity) DESC, i.itemId DESC ")
-    List<Item> findNewItemOrderByOrders(@Param("createdAt") LocalDateTime createdAt,
-        @Param("totalOrderedQuantity") int totalOrderedQuantity, Pageable pageable);
-
-    // 신상품 - 가격 높은 순
-    List<Item> findByCreatedAtAfterAndPriceLessThanOrderByPriceDescItemIdDesc(
-        LocalDateTime createdAt, int price, Pageable pageable);
-
-    // 신상품 - 가격 낮은 순
-    List<Item> findByCreatedAtAfterAndPriceGreaterThanOrderByPriceAscItemIdDesc(
-        LocalDateTime createdAt, int price, Pageable pageable);
-
-    // 신상품 - 최근 등록 순
-    List<Item> findByCreatedAtAfterAndItemIdLessThanOrderByCreatedAtDesc(LocalDateTime createdAt,
-        Long itemId, Pageable pageable);
-
-    // 신상품 - 할인순
-    List<Item> findByCreatedAtAfterAndDiscountLessThanOrderByDiscountDescItemIdDesc(
-        LocalDateTime createdAt, int discount, Pageable pageable);
-
-    // 총 주문 수의 아이템 찾기
-    @Query("SELECT i FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i " + "GROUP BY i.itemId "
-        + "HAVING SUM(oi.quantity) = :totalOrderedQuantity " + "ORDER BY i.itemId ASC")
-    List<Item> findItemByTotalOrderedQuantity(
-        @Param("totalOrderedQuantity") int totalOrderedQuantity);
-
-    // 인기 상품 -> 주문 10회 이상 & 평점 3.8 이상
-    // 인기 상품 - 가격 높은 순
-    @Query(
-        "SELECT i FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i " + "WHERE i.rate >= 3.8 "
-            + "AND i.price < :price " + "GROUP BY i.itemId " + "HAVING SUM(oi.quantity) >= 10 "
-            + "ORDER BY i.price DESC, i.itemId DESC ")
-    List<Item> findHotItemOrderByPriceDesc(@Param("price") int price, Pageable pageable);
-
-    // 인기 상품 - 가격 낮은 순
-    @Query(
-        "SELECT i FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i " + "WHERE i.rate >= 3.8 "
-            + "AND i.price > :price " + "GROUP BY i.itemId " + "HAVING SUM(oi.quantity) >= 10 "
-            + "ORDER BY i.price ASC, i.itemId DESC ")
-    List<Item> findHotItemOrderByPriceAsc(@Param("price") int price, Pageable pageable);
-
-    // 인기 상품 - 최근 등록 순
-    @Query(
-        "SELECT i FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i " + "WHERE i.rate >= 3.8 "
-            + "AND i.itemId < :itemId " + "GROUP BY i.itemId " + "HAVING SUM(oi.quantity) >= 10 "
-            + "ORDER BY i.itemId DESC ")
-    List<Item> findHotItemOrderByItemIdDesc(@Param("itemId") Long itemId, Pageable pageable);
-
-    // 인기 상품 - 할인순
-    @Query(
-        "SELECT i FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i " + "WHERE i.rate >= 3.8 "
-            + "AND i.discount < :discount " + "GROUP BY i.itemId "
-            + "HAVING SUM(oi.quantity) >= 10 " + "ORDER BY i.discount DESC, i.itemId DESC ")
-    List<Item> findHotItemOrderByDiscountDesc(@Param("discount") int discount, Pageable pageable);
-
-    // 인기 상품 - 주문 많은 순
-    @Query("SELECT i " + "FROM Item i " + "LEFT JOIN OrderItem oi ON oi.item = i "
-        + "WHERE i.rate >= 3.8 " + "GROUP BY i " + "HAVING SUM(oi.quantity) >= 10 AND "
-        + "SUM(oi.quantity) < :totalOrders " + "ORDER BY SUM(oi.quantity) DESC, i.itemId DESC ")
-    List<Item> findHotItemOrderByOrdersDesc(@Param("totalOrders") int totalOrders,
-        Pageable pageable);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.prgrms.nabmart.domain.item.repository;
 
+import com.prgrms.nabmart.domain.category.MainCategory;
 import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.ItemSortType;
 import java.util.List;
@@ -11,5 +12,9 @@ public interface ItemRepositoryCustom {
         Pageable pageable);
 
     List<Item> findHotItemsOrderBy(Long lastIdx, Long lastItemId, ItemSortType sortType,
+        Pageable pageable);
+
+    List<Item> findByMainCategoryOrderBy(MainCategory mainCategory, Long lastIdx, Long lastItemId,
+        ItemSortType sortType,
         Pageable pageable);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.prgrms.nabmart.domain.item.repository;
 
 import com.prgrms.nabmart.domain.category.MainCategory;
+import com.prgrms.nabmart.domain.category.SubCategory;
 import com.prgrms.nabmart.domain.item.Item;
 import com.prgrms.nabmart.domain.item.ItemSortType;
 import java.util.List;
@@ -15,6 +16,8 @@ public interface ItemRepositoryCustom {
         Pageable pageable);
 
     List<Item> findByMainCategoryOrderBy(MainCategory mainCategory, Long lastIdx, Long lastItemId,
-        ItemSortType sortType,
-        Pageable pageable);
+        ItemSortType sortType, Pageable pageable);
+
+    List<Item> findBySubCategoryOrderBy(MainCategory mainCategory, SubCategory subCategory,
+        Long lastIdx, Long lastItemId, ItemSortType sortType, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/ItemService.java
@@ -139,50 +139,24 @@ public class ItemService {
     private List<Item> findItemsByMainCategoryFrom(
         FindItemsByCategoryCommand findItemsByCategoryCommand) {
 
+        Long lastItemId = findItemsByCategoryCommand.lastItemId();
         Long lastIdx = findItemsByCategoryCommand.lastIdx();
-        Long option = findItemsByCategoryCommand.option();
         ItemSortType itemSortType = findItemsByCategoryCommand.itemSortType();
         PageRequest pageRequest = findItemsByCategoryCommand.pageRequest();
         String mainCategoryName = findItemsByCategoryCommand.mainCategoryName().toLowerCase();
         MainCategory mainCategory = mainCategoryRepository.findByName(mainCategoryName)
             .orElseThrow(() -> new NotFoundCategoryException("없는 대카테고리입니다."));
 
-        switch (itemSortType) {
-            case NEW -> {
-                return itemRepository.findByItemIdLessThanAndMainCategoryOrderByItemIdDesc(
-                    lastIdx, mainCategory, pageRequest);
-            }
-            case HIGHEST_AMOUNT -> {
-                int price = option.intValue();
-                return itemRepository.findByMainCategoryAndPriceDesc(
-                    lastIdx, price, mainCategory, pageRequest);
-            }
-            case LOWEST_AMOUNT -> {
-                int price = option.intValue();
-                return itemRepository.findByByMainCategoryAndPriceAsc(
-                    lastIdx, price, mainCategory, pageRequest);
-            }
-            case DISCOUNT -> {
-                int discountRate = option.intValue();
-                return itemRepository.findByMainCategoryAndDiscountDesc(
-                    lastIdx, discountRate, mainCategory, pageRequest);
-            }
-            default -> {
-                Long totalOrderedQuantity = ItemSortType.POPULAR.getDefaultValue();
-                if (lastIdx != ItemSortType.POPULAR.getDefaultValue()) {
-                    totalOrderedQuantity = orderItemRepository.countByOrderItemId(lastIdx);
-                }
-                return itemRepository.findByOrderedQuantityAndMainCategory(
-                    lastIdx, totalOrderedQuantity, mainCategory, pageRequest);
-            }
-        }
+        return itemRepository.findByMainCategoryOrderBy(mainCategory, lastIdx, lastItemId,
+            itemSortType,
+            pageRequest);
     }
 
     private List<Item> findItemsBySubCategoryFrom(
         FindItemsByCategoryCommand findItemsByCategoryCommand) {
 
-        Long lastIdx = findItemsByCategoryCommand.lastIdx();
-        Long option = findItemsByCategoryCommand.option();
+        Long lastIdx = findItemsByCategoryCommand.lastItemId();
+        Long option = findItemsByCategoryCommand.lastIdx();
         ItemSortType itemSortType = findItemsByCategoryCommand.itemSortType();
         PageRequest pageRequest = findItemsByCategoryCommand.pageRequest();
         String mainCategoryName = findItemsByCategoryCommand.mainCategoryName().toLowerCase();

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindItemsByCategoryCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/request/FindItemsByCategoryCommand.java
@@ -7,8 +7,8 @@ import org.springframework.data.domain.PageRequest;
 
 @Slf4j
 public record FindItemsByCategoryCommand(
+    Long lastItemId,
     Long lastIdx,
-    Long option,
     String mainCategoryName,
     String subCategoryName,
     PageRequest pageRequest,
@@ -17,17 +17,19 @@ public record FindItemsByCategoryCommand(
     private static final int DEFAULT_PAGE_NUMBER = 0;
 
     public static FindItemsByCategoryCommand of(
-        Long lastIdx, Long option, String mainCategoryName, String subCategoryName, int pageSize,
+        Long lastItemId, Long lastIdx, String mainCategoryName, String subCategoryName,
+        int pageSize,
         String sortType
     ) {
         validateMainCategoryName(mainCategoryName);
         ItemSortType itemSortType = ItemSortType.from(sortType);
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, pageSize);
-        if (isFirstItemId(option)) {
-            option = redeclareLastIdx(itemSortType);
-            lastIdx = Long.MAX_VALUE;
+        if (isFirstItemId(lastItemId)) {
+            lastIdx = redeclareLastIdx(itemSortType);
+            lastItemId = Long.MAX_VALUE;
         }
-        return new FindItemsByCategoryCommand(lastIdx, option, mainCategoryName, subCategoryName,
+        return new FindItemsByCategoryCommand(lastItemId, lastIdx, mainCategoryName,
+            subCategoryName,
             pageRequest,
             itemSortType);
     }

--- a/src/test/java/com/prgrms/nabmart/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/controller/ItemControllerTest.java
@@ -55,14 +55,14 @@ class ItemControllerTest extends BaseControllerTest {
 
             // Then&When
             mockMvc.perform(get("/api/v1/items")
-                    .queryParam("lastIdx", "5")
+                    .queryParam("lastItemId", "5")
                     .queryParam("size", "3")
                     .queryParam("main", mainCategoryName)
                     .queryParam("sort", "DISCOUNT"))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                     queryParameters(
-                        parameterWithName("lastIdx").description("마지막에 조회한 아이템 Id"),
+                        parameterWithName("lastItemId").description("마지막에 조회한 아이템 Id"),
                         parameterWithName("size").description("조회할 아이템 수"),
                         parameterWithName("main").description("대카테고리명"),
                         parameterWithName("sort").description("정렬 기준명")
@@ -79,7 +79,7 @@ class ItemControllerTest extends BaseControllerTest {
 
             // Then&When
             mockMvc.perform(get("/api/v1/items")
-                    .queryParam("lastIdx", "5")
+                    .queryParam("lastItemId", "5")
                     .queryParam("size", "3")
                     .queryParam("main", mainCategoryName)
                     .queryParam("sub", subCategoryName)
@@ -87,7 +87,7 @@ class ItemControllerTest extends BaseControllerTest {
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                     queryParameters(
-                        parameterWithName("lastIdx").description("마지막에 조회한 아이템 Id"),
+                        parameterWithName("lastItemId").description("마지막에 조회한 아이템 Id"),
                         parameterWithName("size").description("조회할 아이템 수"),
                         parameterWithName("main").description("대카테고리명"),
                         parameterWithName("sub").description("대카테고리에 속한 소카테고리명"),
@@ -164,7 +164,7 @@ class ItemControllerTest extends BaseControllerTest {
             // When
             ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/items/new")
-                    .queryParam("lastIdx", "1")
+                    .queryParam("lastItemId", "1")
                     .queryParam("lastItemId", "1")
                     .queryParam("size", "5")
                     .queryParam("sort", "NEW")
@@ -174,7 +174,7 @@ class ItemControllerTest extends BaseControllerTest {
             resultActions.andExpect(status().isOk())
                 .andDo(document("Find New Items",
                     queryParameters(
-                        parameterWithName("lastIdx").description("마지막에 조회한 아이템의 특성값"),
+                        parameterWithName("lastItemId").description("마지막에 조회한 아이템의 특성값"),
                         parameterWithName("lastItemId").description("마지막에 조회한 아이템 ID"),
                         parameterWithName("size").description("조회할 아이템 수"),
                         parameterWithName("sort").description("정렬 기준명")
@@ -216,7 +216,7 @@ class ItemControllerTest extends BaseControllerTest {
             // When
             ResultActions resultActions = mockMvc.perform(
                 get("/api/v1/items/hot")
-                    .queryParam("lastIdx", "-1")
+                    .queryParam("lastItemId", "-1")
                     .queryParam("lastItemId", "-1")
                     .queryParam("size", "3")
                     .queryParam("sort", "NEW")
@@ -226,7 +226,7 @@ class ItemControllerTest extends BaseControllerTest {
             resultActions.andExpect(status().isOk())
                 .andDo(document("Find Hot Items",
                     queryParameters(
-                        parameterWithName("lastIdx").description("마지막에 조회한 아이템의 특성값"),
+                        parameterWithName("lastItemId").description("마지막에 조회한 아이템의 특성값"),
                         parameterWithName("lastItemId").description("마지막에 조회한 아이템 ID"),
                         parameterWithName("size").description("조회할 아이템 수"),
                         parameterWithName("sort").description("정렬 기준명")

--- a/src/test/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/repository/ItemRepositoryTest.java
@@ -66,8 +66,7 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), 1, "0", 1, 1, 1, mainCategory, subCategory);
-                itemRepository.save(item);
+                Item item = getSavedItem(i, 1, "0", 1, 1, 1, mainCategory, null);
                 savedItems.add(item);
             }
 
@@ -99,10 +98,8 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), 0, "0", 0, (int) (Math.random() * 100), 0,
-                    mainCategory,
-                    subCategory);
-                itemRepository.save(item);
+                getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, null);
             }
 
             // When
@@ -121,10 +118,8 @@ class ItemRepositoryTest {
             //Given
             mainCategoryRepository.save(mainCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
-                    mainCategory,
-                    null);
-                itemRepository.save(item);
+                getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, null);
             }
 
             // When
@@ -144,12 +139,9 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
-                    mainCategory,
-                    subCategory);
-                itemRepository.save(item);
+                getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, null);
             }
-
             // When
             PageRequest pageRequest = PageRequest.of(0, 5);
             List<Item> items = itemRepository.findByMainCategoryOrderBy(
@@ -160,6 +152,7 @@ class ItemRepositoryTest {
             assertThat(items.size()).isEqualTo(5);
         }
 
+
         @Test
         @DisplayName("인기 순으로 조회된다.")
         public void findByOrderCount() {
@@ -168,14 +161,12 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
-                    mainCategory,
-                    subCategory);
-                itemRepository.save(item);
+                Item item = getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, subCategory);
                 OrderItem orderItem = new OrderItem(item, (50 - i));
                 orderItemRepository.save(orderItem);
             }
-            List<Long> expected = List.of(1L, 2L, 3L, 4L, 5L);
+            List<Long> expectedItemIds = List.of(1L, 2L, 3L, 4L, 5L);
 
             // When
             PageRequest pageRequest = PageRequest.of(0, 5);
@@ -183,13 +174,9 @@ class ItemRepositoryTest {
                 mainCategory, 10000L, Long.MAX_VALUE,
                 ItemSortType.POPULAR, pageRequest);
 
-            List<Long> actual = items.stream()
-                .map(Item::getItemId)
-                .toList();
             // Then
-            assertThat(items.size()).isEqualTo(5);
-            assertThat(expected).usingRecursiveComparison()
-                .isEqualTo(actual);
+            assertThat(items).map(Item::getItemId)
+                .isEqualTo(expectedItemIds);
         }
     }
 
@@ -208,8 +195,7 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), 1, "0", 1, 1, 1, mainCategory, subCategory);
-                itemRepository.save(item);
+                Item item = getSavedItem(i, 1, "0", 1, 1, 1, mainCategory, subCategory);
                 savedItems.add(item);
             }
 
@@ -241,10 +227,9 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), 0, "0", 0, (int) (Math.random() * 100), 0,
+                getSavedItem(i, 0, "0", 0, (int) (Math.random() * 100), 0,
                     mainCategory,
                     subCategory);
-                itemRepository.save(item);
             }
 
             // When
@@ -264,10 +249,8 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
-                    mainCategory,
-                    subCategory);
-                itemRepository.save(item);
+                getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, subCategory);
             }
 
             // When
@@ -287,10 +270,8 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
-                    mainCategory,
-                    subCategory);
-                itemRepository.save(item);
+                getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
+                    mainCategory, subCategory);
             }
 
             // When
@@ -311,10 +292,9 @@ class ItemRepositoryTest {
             mainCategoryRepository.save(mainCategory);
             subCategoryRepository.save(subCategory);
             for (int i = 0; i < 50; i++) {
-                Item item = new Item("item" + (i + 1), (int) (Math.random() * 1000), "0", 0, 0, 0,
+                Item item = getSavedItem(i, (int) (Math.random() * 1000), "0", 0, 0, 0,
                     mainCategory,
                     subCategory);
-                itemRepository.save(item);
                 OrderItem orderItem = new OrderItem(item, (50 - i));
                 orderItemRepository.save(orderItem);
             }
@@ -377,5 +357,15 @@ class ItemRepositoryTest {
             assertThat(findItem).isNotEmpty();
             assertThat(findItem.get().getQuantity()).isEqualTo(originQuantity + increaseQuantity);
         }
+    }
+
+    private Item getSavedItem(int i, int price, String description, int quantity, int discount,
+        int maxBuyQuantity, MainCategory mainCategory, SubCategory subCategory) {
+
+        Item item = new Item(
+            "item" + (i + 1), price, description, quantity, discount, maxBuyQuantity,
+            mainCategory, subCategory);
+        itemRepository.save(item);
+        return item;
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
@@ -128,8 +128,8 @@ class ItemServiceTest {
                 ItemSortType.NEW);
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
-            when(itemRepository.findByItemIdLessThanAndMainCategoryOrderByItemIdDesc(anyLong(),
-                any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findByMainCategoryOrderBy(any(), anyLong(), anyLong(), any(),
+                any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -149,10 +149,9 @@ class ItemServiceTest {
                 .toList();
             FindItemsByCategoryCommand findItemsByCategoryCommand = getFindItemsByCategoryCommand(
                 ItemSortType.DISCOUNT);
-
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
-            when(itemRepository.findByMainCategoryAndDiscountDesc(
-                anyLong(), anyInt(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findByMainCategoryOrderBy(
+                any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -171,8 +170,8 @@ class ItemServiceTest {
                 ItemSortType.HIGHEST_AMOUNT);
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
-            when(itemRepository.findByMainCategoryAndPriceDesc(
-                anyLong(), anyInt(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findByMainCategoryOrderBy(any(), anyLong(), anyLong(), any(),
+                any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -191,8 +190,8 @@ class ItemServiceTest {
                 ItemSortType.LOWEST_AMOUNT);
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
-            when(itemRepository.findByByMainCategoryAndPriceAsc(
-                anyLong(), anyInt(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findByMainCategoryOrderBy(any(), anyLong(), anyLong(), any(),
+                any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -211,9 +210,8 @@ class ItemServiceTest {
                 ItemSortType.POPULAR);
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
-            when(orderItemRepository.countByOrderItemId(anyLong())).thenReturn(Long.MAX_VALUE);
-            when(itemRepository.findByOrderedQuantityAndMainCategory(
-                anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findByMainCategoryOrderBy(
+                any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/ItemServiceTest.java
@@ -2,7 +2,6 @@ package com.prgrms.nabmart.domain.item.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -284,8 +283,8 @@ class ItemServiceTest {
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
             when(subCategoryRepository.findByName(any())).thenReturn(Optional.of(subCategory));
-            when(itemRepository.findByItemIdLessThanAndMainCategoryAndSubCategoryOrderByItemIdDesc(
-                anyLong(), any(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findBySubCategoryOrderBy(
+                any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -308,9 +307,8 @@ class ItemServiceTest {
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
             when(subCategoryRepository.findByName(any())).thenReturn(Optional.of(subCategory));
-            when(
-                itemRepository.findBySubCategoryAndDiscountDesc(
-                    anyLong(), anyInt(), any(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findBySubCategoryOrderBy(
+                any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -330,9 +328,8 @@ class ItemServiceTest {
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
             when(subCategoryRepository.findByName(any())).thenReturn(Optional.of(subCategory));
-            when(
-                itemRepository.findBySubCategoryAndPriceDesc(
-                    anyLong(), anyInt(), any(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findBySubCategoryOrderBy(
+                any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -352,9 +349,8 @@ class ItemServiceTest {
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
             when(subCategoryRepository.findByName(any())).thenReturn(Optional.of(subCategory));
-            when(
-                itemRepository.findBySubCategoryAndPriceAsc(
-                    anyLong(), anyInt(), any(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findBySubCategoryOrderBy(
+                any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(
@@ -374,9 +370,8 @@ class ItemServiceTest {
 
             when(mainCategoryRepository.findByName(any())).thenReturn(Optional.of(mainCategory));
             when(subCategoryRepository.findByName(any())).thenReturn(Optional.of(subCategory));
-            when(orderItemRepository.countByOrderItemId(anyLong())).thenReturn(Long.MAX_VALUE);
-            when(itemRepository.findByOrderedQuantityAndMainCategoryAndSubCategory(
-                anyLong(), anyLong(), any(), any(), any())).thenReturn(expectedItems);
+            when(itemRepository.findBySubCategoryOrderBy(
+                any(), any(), anyLong(), anyLong(), any(), any())).thenReturn(expectedItems);
 
             // When
             FindItemsResponse itemsResponse = itemService.findItemsByCategory(


### PR DESCRIPTION
### ⛏ 작업 사항
- 동적쿼리를 적용 시켜, 기존 Service Layer의 분기처리를 제거했습니다.

### 📝 작업 요약
-  Service Layer 내부에서 분기처리 -> **동적쿼리(querydsl) 적용하여 Repository Layer 내부에서 동적으로 조회처리**

### 💡 관련 이슈

