### PR TITLE
[NAYB-109] refactor: 회원의 등급 업데이트 로직 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/repository/UserRepository.java
@@ -6,7 +6,6 @@ import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,12 +17,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select o.user.userId as userId, count(o) as orderCount from Order o"
         + " where o.createdAt between :start and :end"
-        + " group by o.user.userId"
-        + " order by o.user.userId asc")
+        + " group by o.user.userId")
     List<UserOrderCount> getUserOrderCount(
         @Param("start") LocalDateTime start,
-        @Param("end") LocalDateTime end,
-        Pageable pageable);
+        @Param("end") LocalDateTime end);
 
     @Modifying
     @Query("update User u set u.userGrade = :userGrade"

--- a/src/main/java/com/prgrms/nabmart/domain/user/scheduler/GradeScheduler.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/scheduler/GradeScheduler.java
@@ -1,5 +1,6 @@
-package com.prgrms.nabmart.domain.user.service;
+package com.prgrms.nabmart.domain.user.scheduler;
 
+import com.prgrms.nabmart.domain.user.service.GradeService;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/GradeScheduler.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/GradeScheduler.java
@@ -1,0 +1,23 @@
+package com.prgrms.nabmart.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@EnableSchedulerLock(defaultLockAtMostFor = "PT60S")
+public class GradeScheduler {
+
+    private final GradeService gradeService;
+
+    @Async
+    @Scheduled(cron = "0 0 5 1 * *")
+    @SchedulerLock(name = "Update_User_Grade", lockAtLeastFor = "PT10S")
+    public void updateUserGradeScheduler() {
+        gradeService.updateUserGrade();
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.groupingBy;
 import com.prgrms.nabmart.domain.user.UserGrade;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
-import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -13,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -22,30 +20,20 @@ import org.springframework.stereotype.Service;
 public class GradeService {
 
     private static final int ONE = 1;
-    private static final int PAGE_SIZE = 1000;
 
     private final UserRepository userRepository;
-    private final EntityManager entityManager;
 
     @Transactional
     public void updateUserGrade() {
-        long totalUserCount = userRepository.count();
-        long totalPage = totalUserCount / PAGE_SIZE;
         LocalDateTime startTimeOfPreviousMonth = getStartTimeOfPreviousMonth();
         LocalDateTime lastTimeOfPreviousMonth = getEndTimeOfPreviousMonth();
 
-        for (int page = 0; page <= totalPage; page++) {
-            PageRequest pageRequest = PageRequest.of(page, PAGE_SIZE);
-            List<UserOrderCount> userOrderCounts = userRepository.getUserOrderCount(
-                startTimeOfPreviousMonth,
-                lastTimeOfPreviousMonth,
-                pageRequest);
-            Map<UserGrade, List<UserOrderCount>> userGradeGroup = groupByUserGrade(userOrderCounts);
-            userGradeGroup.forEach(((userGrade, userOrderCountGroup) ->
-                userRepository.updateUserGrade(userGrade, extractUserIds(userOrderCountGroup))));
-
-            entityManager.clear();
-        }
+        List<UserOrderCount> userOrderCounts = userRepository.getUserOrderCount(
+            startTimeOfPreviousMonth,
+            lastTimeOfPreviousMonth);
+        Map<UserGrade, List<UserOrderCount>> userGradeGroup = groupByUserGrade(userOrderCounts);
+        userGradeGroup.forEach(((userGrade, userOrderCountGroup) ->
+            userRepository.updateUserGrade(userGrade, extractUserIds(userOrderCountGroup))));
     }
 
     private LocalDateTime getStartTimeOfPreviousMonth() {

--- a/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/user/service/GradeService.java
@@ -13,17 +13,12 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@EnableSchedulerLock(defaultLockAtMostFor = "PT60S")
 public class GradeService {
 
     private static final int ONE = 1;
@@ -32,9 +27,6 @@ public class GradeService {
     private final UserRepository userRepository;
     private final EntityManager entityManager;
 
-    @Async
-    @Scheduled(cron = "0 0 5 1 * *")
-    @SchedulerLock(name = "Update_User_Grade", lockAtLeastFor = "PT10S")
     @Transactional
     public void updateUserGrade() {
         long totalUserCount = userRepository.count();

--- a/src/test/java/com/prgrms/nabmart/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/repository/UserRepositoryTest.java
@@ -23,8 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
 @Import({JpaAuditingConfig.class, TestQueryDslConfig.class})
@@ -77,7 +75,6 @@ class UserRepositoryTest {
     @DisplayName("getUserOrderCount 메서드 실행 시")
     class GetUserOrderCountTest {
 
-        Pageable pageable = PageRequest.of(0, 5);
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime start = now.minusDays(1);
         LocalDateTime end = now.plusDays(1);
@@ -91,7 +88,7 @@ class UserRepositoryTest {
 
             //when
             List<UserOrderCount> userOrderCounts
-                = userRepository.getUserOrderCount(start, end, pageable);
+                = userRepository.getUserOrderCount(start, end);
 
             //then
             assertThat(userOrderCounts).hasSize(1);
@@ -109,7 +106,7 @@ class UserRepositoryTest {
 
             //when
             List<UserOrderCount> userOrderCounts
-                = userRepository.getUserOrderCount(start, end, pageable);
+                = userRepository.getUserOrderCount(start, end);
 
             //then
             assertThat(userOrderCounts).hasSize(2);

--- a/src/test/java/com/prgrms/nabmart/domain/user/service/GradeServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/user/service/GradeServiceTest.java
@@ -6,8 +6,8 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.prgrms.nabmart.domain.user.User;
-import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import com.prgrms.nabmart.domain.user.repository.response.UserOrderCount;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,12 +76,11 @@ class GradeServiceTest {
             UserOrderCount vipCount = createUserOrderCount(users.get(1).getUserId(), 5);
             UserOrderCount vvipCount = createUserOrderCount(users.get(2).getUserId(), 10);
             UserOrderCount rvipCount = createUserOrderCount(users.get(3).getUserId(), 20);
+            List<UserOrderCount> userOrderCounters = List.of(normalCount, vipCount, vvipCount,
+                rvipCount);
 
-            PageImpl<UserOrderCount> givenResult = new PageImpl<>(
-                List.of(normalCount, vipCount, vvipCount, rvipCount));
-            given(userRepository.count()).willReturn(4L);
-            given(userRepository.getUserOrderCount(any(), any(), any())).willReturn(
-                givenResult.getContent());
+            given(userRepository.getUserOrderCount(any(), any())).willReturn(
+                userOrderCounters);
 
             //when
             gradeService.updateUserGrade();


### PR DESCRIPTION
### ⛏ 작업 사항
- 기존에 서비스 메서드에서 붙어있던 `@Scheduled`를 별도의 스케줄러 클래스로 분리하였습니다.
- 기존 회원 등급 업데이트 시 1000건씩 조회, 등급별 분류, 업데이트를 반복하던 것에서 일괄 조회 후 분류, 업데이트를 수행하도록 변경하였습니다.


### 📝 작업 요약
- `GradeService`로부터 스케줄링 어노테이션을 `GradeScheduler`로 분리
- `GradeService` `updateUserGrade` 메서드가 호출하는 리포지토리 쿼리를 페이지네이션에서 일괄 조회로 변경


### 💡 관련 이슈
- [NAYB-109](https://naybmart.atlassian.net/browse/NAYB-109)


[NAYB-109]: https://naybmart.atlassian.net/browse/NAYB-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ