### PR TITLE
[NAYB-137] 구매자는 주문내역을 삭제 할 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/order/controller/OrderController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/controller/OrderController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,6 +72,15 @@ public class OrderController {
         @LoginUser Long userId
     ) {
         return ResponseEntity.ok(orderService.findOrders(userId, page));
+    }
+
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<Void> deleteOrder(
+        @PathVariable Long orderId,
+        @LoginUser Long userId
+    ) {
+        orderService.deleteOrder(orderId, userId);
+        return ResponseEntity.noContent().build();
     }
 
     @ExceptionHandler(OrderException.class)

--- a/src/main/java/com/prgrms/nabmart/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/repository/OrderRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
@@ -20,8 +21,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByUuidAndUser_UserId(String uuid, Long userId);
 
     @Query("SELECT o FROM Order o WHERE o.createdAt <= :expiredTime AND o.status IN :statusList")
-    List<Order> findByStatusInBeforeExpiredTime(LocalDateTime expiredTime,
-        List<OrderStatus> statusList);
+    List<Order> findByStatusInBeforeExpiredTime(@Param("expiredTime") LocalDateTime expiredTime,
+        @Param("statusList") List<OrderStatus> statusList);
 
     void deleteByUser(User findUser);
 }

--- a/src/main/java/com/prgrms/nabmart/domain/order/service/OrderService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/order/service/OrderService.java
@@ -87,6 +87,22 @@ public class OrderService {
         }
     }
 
+    @Transactional
+    public void cancelOrder(final Order order) {
+        order.updateOrderStatus(OrderStatus.CANCELED);
+        order.unUseCoupon();
+        order.getOrderItems().forEach(
+            orderItem -> itemRepository.increaseQuantity(orderItem.getItem().getItemId(),
+                orderItem.getQuantity())
+        );
+    }
+
+    @Transactional
+    public void deleteOrder(final Long orderId, final Long userId) {
+        Order order = getOrderByOrderIdAndUserId(orderId, userId);
+        orderRepository.delete(order);
+    }
+
     private static void updateItemQuantity(Order order) {
         List<OrderItem> orderItems = order.getOrderItems();
         for (OrderItem orderItem : orderItems) {
@@ -158,15 +174,5 @@ public class OrderService {
     private Item findItemByItemId(final Long itemId) {
         return itemRepository.findByItemId(itemId)
             .orElseThrow(() -> new NotFoundItemException("존재하지 않는 상품입니다."));
-    }
-
-    @Transactional
-    public void cancelOrder(final Order order) {
-        order.updateOrderStatus(OrderStatus.CANCELED);
-        order.unUseCoupon();
-        order.getOrderItems().forEach(
-            orderItem -> itemRepository.increaseQuantity(orderItem.getItem().getItemId(),
-                orderItem.getQuantity())
-        );
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/controller/OrderControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -197,6 +198,30 @@ public class OrderControllerTest extends BaseControllerTest {
                         fieldWithPath("totalPrice").type(NUMBER).description("쿠폰 적용후 총 가격"),
                         fieldWithPath("discountPrice").type(NUMBER).description("쿠폰 할인 금액")
                     )));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteOrder 메서드 실행 시")
+    class DeleteOrder {
+
+        @Test
+        @DisplayName("성공")
+        void deleteOrder() throws Exception {
+            // given
+            User user = user();
+            Order order = pendingOrder(1L, user);
+
+            // when
+            ResultActions result = mockMvc.perform(
+                delete("/api/v1/orders/{orderId}", order.getOrderId())
+                    .header(AUTHORIZATION, accessToken));
+
+            // then
+            result
+                .andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                ));
         }
     }
 }

--- a/src/test/java/com/prgrms/nabmart/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/order/service/OrderServiceTest.java
@@ -321,5 +321,24 @@ public class OrderServiceTest {
                 orderItem.getQuantity());
         }
     }
-}
 
+    @Nested
+    @DisplayName("deleteOrder 메서드 실행 시")
+    class DeleteOrder {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Order order = pendingOrder(1L, user());
+
+            // when
+            when(orderRepository.findByOrderIdAndUser_UserId(order.getOrderId(),
+                user().getUserId())).thenReturn(Optional.of(order));
+            orderService.deleteOrder(order.getOrderId(), user().getUserId());
+
+            // then
+            verify(orderRepository, times(1)).delete(order);
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- findByStatusInBeforeExpiredTime @param 추가
- deleteOrder 주문내역 삭제 로직 추가
- 주문 내역 삭제 API 구현
- deleteOrder Service, Controller 테스트 코드 작성

### 📝 작업 요약
- 주문 내역 삭제 API 구현
- 주문 내역 삭제 test


### 💡 관련 이슈
[NAYB-137](https://naybmart.atlassian.net/jira/software/projects/NAYB/boards/4?selectedIssue=NAYB-137)



[NAYB-137]: https://naybmart.atlassian.net/browse/NAYB-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ