### PR TITLE
[NAYB-155] refactor: auth 패키지 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/delivery/service/DeliveryService.java
@@ -4,6 +4,7 @@ import com.prgrms.nabmart.domain.delivery.Delivery;
 import com.prgrms.nabmart.domain.delivery.Rider;
 import com.prgrms.nabmart.domain.delivery.exception.NotFoundDeliveryException;
 import com.prgrms.nabmart.domain.delivery.exception.NotFoundRiderException;
+import com.prgrms.nabmart.domain.delivery.exception.UnauthorizedDeliveryException;
 import com.prgrms.nabmart.domain.delivery.repository.DeliveryRepository;
 import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
 import com.prgrms.nabmart.domain.delivery.service.request.AcceptDeliveryCommand;
@@ -18,7 +19,6 @@ import com.prgrms.nabmart.domain.delivery.service.response.FindWaitingDeliveries
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
-import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -42,7 +42,7 @@ public class DeliveryService {
 
     private void checkAuthority(final Delivery delivery, final User user) {
         if (!delivery.isOwnByUser(user)) {
-            throw new AuthorizationException("권한이 없습니다.");
+            throw new UnauthorizedDeliveryException("권한이 없습니다.");
         }
     }
 

--- a/src/main/java/com/prgrms/nabmart/domain/item/exception/UnauthorizedLikeItemException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/exception/UnauthorizedLikeItemException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.item.exception;
+
+public class UnauthorizedLikeItemException extends ItemException {
+
+    public UnauthorizedLikeItemException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/item/exception/UnauthorizedLikeItemException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/exception/UnauthorizedLikeItemException.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.domain.item.exception;
 
 public class UnauthorizedLikeItemException extends ItemException {
 
-    public UnauthorizedLikeItemException(String message) {
+    public UnauthorizedLikeItemException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/item/service/LikeItemService.java
@@ -5,6 +5,7 @@ import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.exception.DuplicateLikeItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
+import com.prgrms.nabmart.domain.item.exception.UnauthorizedLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
@@ -14,7 +15,6 @@ import com.prgrms.nabmart.domain.item.service.response.FindLikeItemsResponse;
 import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
-import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -42,7 +42,7 @@ public class LikeItemService {
     public void deleteLikeItem(DeleteLikeItemCommand deleteLikeItemCommand) {
         LikeItem likeItem = findLikeItemByLikeItemId(deleteLikeItemCommand);
         if (!likeItem.isSameUser(deleteLikeItemCommand.userId())) {
-            throw new AuthorizationException("권한이 없습니다.");
+            throw new UnauthorizedLikeItemException("권한이 없습니다.");
         }
         likeItemRepository.delete(likeItem);
     }

--- a/src/main/java/com/prgrms/nabmart/global/auth/controller/AuthControllerAdvice.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/controller/AuthControllerAdvice.java
@@ -1,6 +1,8 @@
 package com.prgrms.nabmart.global.auth.controller;
 
 import com.prgrms.nabmart.global.auth.exception.AuthException;
+import com.prgrms.nabmart.global.auth.exception.DuplicateUsernameException;
+import com.prgrms.nabmart.global.auth.exception.InvalidJwtException;
 import com.prgrms.nabmart.global.auth.exception.OAuthUnlinkFailureException;
 import com.prgrms.nabmart.global.auth.exception.UnAuthenticationException;
 import com.prgrms.nabmart.global.util.ErrorTemplate;
@@ -18,9 +20,16 @@ public class AuthControllerAdvice {
             .body(ErrorTemplate.of(ex.getMessage()));
     }
 
-    @ExceptionHandler({OAuthUnlinkFailureException.class, UnAuthenticationException.class})
-    public ResponseEntity<ErrorTemplate> authenticationFailExHand(AuthException ex) {
+    @ExceptionHandler({OAuthUnlinkFailureException.class, UnAuthenticationException.class,
+        InvalidJwtException.class})
+    public ResponseEntity<ErrorTemplate> authenticationFailExHandle(AuthException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorTemplate.of(ex.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateUsernameException.class)
+    public ResponseEntity<ErrorTemplate> duplicateUsernameExHandle(AuthException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
             .body(ErrorTemplate.of(ex.getMessage()));
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/controller/AuthControllerAdvice.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/controller/AuthControllerAdvice.java
@@ -1,5 +1,8 @@
-package com.prgrms.nabmart.global.auth.exception;
+package com.prgrms.nabmart.global.auth.controller;
 
+import com.prgrms.nabmart.global.auth.exception.AuthException;
+import com.prgrms.nabmart.global.auth.exception.OAuthUnlinkFailureException;
+import com.prgrms.nabmart.global.auth.exception.UnAuthenticationException;
 import com.prgrms.nabmart.global.util.ErrorTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/prgrms/nabmart/global/auth/controller/RiderAuthenticationController.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/controller/RiderAuthenticationController.java
@@ -2,9 +2,9 @@ package com.prgrms.nabmart.global.auth.controller;
 
 import com.prgrms.nabmart.global.auth.controller.request.SignupRiderRequest;
 import com.prgrms.nabmart.global.auth.service.request.SignupRiderCommand;
-import com.prgrms.nabmart.global.auth.controller.request.RiderLoginRequest;
+import com.prgrms.nabmart.global.auth.controller.request.LoginRiderRequest;
 import com.prgrms.nabmart.global.auth.service.RiderAuthenticationService;
-import com.prgrms.nabmart.global.auth.service.request.RiderLoginCommand;
+import com.prgrms.nabmart.global.auth.service.request.LoginRiderCommand;
 import com.prgrms.nabmart.global.auth.service.response.RiderLoginResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -37,11 +37,11 @@ public class RiderAuthenticationController {
 
     @PostMapping("/riders/login")
     public ResponseEntity<RiderLoginResponse> riderLogin(
-        @RequestBody @Valid RiderLoginRequest riderLoginRequest) {
-        RiderLoginCommand riderLoginCommand
-            = RiderLoginCommand.of(riderLoginRequest.username(), riderLoginRequest.password());
+        @RequestBody @Valid LoginRiderRequest loginRiderRequest) {
+        LoginRiderCommand loginRiderCommand
+            = LoginRiderCommand.of(loginRiderRequest.username(), loginRiderRequest.password());
         RiderLoginResponse riderLoginResponse
-            = riderAuthenticationService.riderLogin(riderLoginCommand);
+            = riderAuthenticationService.loginRider(loginRiderCommand);
         return ResponseEntity.ok(riderLoginResponse);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/controller/request/LoginRiderRequest.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/controller/request/LoginRiderRequest.java
@@ -3,7 +3,7 @@ package com.prgrms.nabmart.global.auth.controller.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public record RiderLoginRequest(
+public record LoginRiderRequest(
     @NotNull(message = "사용자 이름은 필수 입니다.")
     @Pattern(regexp = "^(?=.*[a-z])[a-z0-9]{6,20}$",
         message = "사용자 이름은 영어 소문자 또는 영어 소문자와 숫자 6자 이상, 20자 이하로 구성 되어야 합니다.")

--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdvice.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdvice.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class AuthExceptionHandler {
+public class AuthControllerAdvice {
 
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<ErrorTemplate> authExHandle(AuthException ex) {

--- a/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/exception/AuthorizationException.java
@@ -1,8 +1,0 @@
-package com.prgrms.nabmart.global.auth.exception;
-
-public class AuthorizationException extends AuthException {
-
-    public AuthorizationException(final String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/prgrms/nabmart/global/auth/jwt/JavaJwtTokenProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/jwt/JavaJwtTokenProvider.java
@@ -69,6 +69,8 @@ public class JavaJwtTokenProvider implements TokenProvider {
             log.info("SignatureVerificationException: 토큰의 서명이 유효하지 않습니다.");
         } catch (TokenExpiredException ex) {
             log.info("TokenExpiredException: 토큰이 만료되었습니다.");
+        } catch (MissingClaimException ex) {
+            log.info("MissingClaimException: 유효값이 클레임이 포함되어 있지 않습니다.");
         } catch (JWTVerificationException ex) {
             log.info("JWTVerificationException: 유효하지 않은 토큰입니다.");
         }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/OAuthProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/OAuthProvider.java
@@ -1,4 +1,4 @@
-package com.prgrms.nabmart.global.auth.oauth.handler;
+package com.prgrms.nabmart.global.auth.oauth;
 
 import com.prgrms.nabmart.global.auth.exception.InvalidProviderException;
 import com.prgrms.nabmart.global.auth.oauth.client.KakaoMessageProvider;

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/KakaoMessageProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/KakaoMessageProvider.java
@@ -1,5 +1,9 @@
 package com.prgrms.nabmart.global.auth.oauth.client;
 
+import static com.prgrms.nabmart.global.auth.oauth.constant.OAuthConstant.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
 import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import com.prgrms.nabmart.global.auth.exception.OAuthUnlinkFailureException;
 import com.prgrms.nabmart.global.auth.oauth.dto.OAuthHttpMessage;
@@ -8,7 +12,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,25 +22,10 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-@RequiredArgsConstructor
 public class KakaoMessageProvider implements OAuthHttpMessageProvider {
 
     private static final String UNLINK_URI = "https://kapi.kakao.com/v1/user/unlink";
     private static final String ACCESS_TOKEN_REFRESH_URI = "https://kauth.kakao.com/oauth/token";
-    private static final String CONTENT_TYPE = "Content-Type";
-    private static final String AUTHORIZATION = "Authorization";
-    private static final String TARGET_ID_TYPE = "target_id_type";
-    private static final String USER_ID = "user_id";
-    private static final String TARGET_ID = "target_id";
-    private static final String ID = "id";
-    private static final String APPLICATION_X_WWW_FORM_URLENCODED_CHARSET_UTF_8
-        = "application/x-www-form-urlencoded;charset=utf-8";
-    private static final String GRANT_TYPE = "grant_type";
-    private static final String REFRESH_TOKEN = "refresh_token";
-    private static final String CLIENT_ID = "client_id";
-    private static final String CLIENT_SECRET = "client_secret";
-    private static final String ACCESS_TOKEN = "access_token";
-    private static final String EXPIRES_IN = "expires_in";
 
     @Override
     public OAuthHttpMessage createUserUnlinkRequest(
@@ -83,7 +71,8 @@ public class KakaoMessageProvider implements OAuthHttpMessageProvider {
     }
 
     @Override
-    public OAuthHttpMessage createRefreshAccessTokenRequest(OAuth2AuthorizedClient authorizedClient) {
+    public OAuthHttpMessage createRefreshAccessTokenRequest(
+        OAuth2AuthorizedClient authorizedClient) {
         return new OAuthHttpMessage(
             ACCESS_TOKEN_REFRESH_URI,
             createRefreshAccessTokenMessage(authorizedClient),

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/KakaoMessageProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/KakaoMessageProvider.java
@@ -28,11 +28,11 @@ public class KakaoMessageProvider implements OAuthHttpMessageProvider {
     private static final String ACCESS_TOKEN_REFRESH_URI = "https://kauth.kakao.com/oauth/token";
 
     @Override
-    public OAuthHttpMessage createUserUnlinkRequest(
+    public OAuthHttpMessage createUnlinkUserRequest(
         final FindUserDetailResponse userDetailResponse,
         final OAuth2AuthorizedClient authorizedClient) {
         String accessToken = getAccessToken(authorizedClient);
-        HttpEntity<MultiValueMap<String, String>> unlinkHttpMeesage = createUnlinkOAuthUserMessage(
+        HttpEntity<MultiValueMap<String, String>> unlinkHttpMeesage = createUnlinkUserMessage(
             userDetailResponse, accessToken);
         return new OAuthHttpMessage(UNLINK_URI, unlinkHttpMeesage, new HashMap<>());
     }
@@ -41,11 +41,12 @@ public class KakaoMessageProvider implements OAuthHttpMessageProvider {
         return authorizedClient.getAccessToken().getTokenValue();
     }
 
-    private HttpEntity<MultiValueMap<String, String>> createUnlinkOAuthUserMessage(
+    private HttpEntity<MultiValueMap<String, String>> createUnlinkUserMessage(
         final FindUserDetailResponse userDetailResponse,
         final String accessToken) {
         HttpHeaders headers = createHeader(accessToken);
-        MultiValueMap<String, String> multiValueMap = createUnlinkMessageBody(userDetailResponse);
+        MultiValueMap<String, String> multiValueMap
+            = createUnlinkUserMessageBody(userDetailResponse);
         return new HttpEntity<>(multiValueMap, headers);
     }
 
@@ -56,7 +57,7 @@ public class KakaoMessageProvider implements OAuthHttpMessageProvider {
         return headers;
     }
 
-    private MultiValueMap<String, String> createUnlinkMessageBody(
+    private MultiValueMap<String, String> createUnlinkUserMessageBody(
         final FindUserDetailResponse userDetailResponse) {
         MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
         multiValueMap.add(TARGET_ID_TYPE, USER_ID);
@@ -65,7 +66,7 @@ public class KakaoMessageProvider implements OAuthHttpMessageProvider {
     }
 
     @Override
-    public void checkSuccessUnlinkRequest(Map<String, Object> unlinkResponse) {
+    public void verifySuccessUnlinkUserRequest(Map<String, Object> unlinkResponse) {
         Optional.ofNullable(unlinkResponse.get(ID))
             .orElseThrow(() -> new OAuthUnlinkFailureException("소셜 로그인 연동 해제가 실패하였습니다."));
     }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/NaverMessageProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/NaverMessageProvider.java
@@ -31,12 +31,12 @@ public class NaverMessageProvider implements OAuthHttpMessageProvider {
         + "client_secret={client_secret}&refresh_token={refresh_token}";
 
     @Override
-    public OAuthHttpMessage createUserUnlinkRequest(
+    public OAuthHttpMessage createUnlinkUserRequest(
         final FindUserDetailResponse userDetailResponse,
         final OAuth2AuthorizedClient authorizedClient) {
         String accessToken = getAccessToken(authorizedClient);
-        HttpEntity<MultiValueMap<String, String>> unlinkHttpMessage = createUnlinkOAuthUserMessage();
-        Map<String, String> unlinkUriVariables = createUnlinkUriVariables(
+        HttpEntity<MultiValueMap<String, String>> unlinkHttpMessage = createUnlinkUserMessage();
+        Map<String, String> unlinkUriVariables = createUnlinkUserUriVariables(
             authorizedClient.getClientRegistration(), accessToken);
         return new OAuthHttpMessage(UNLINK_URI, unlinkHttpMessage, unlinkUriVariables);
     }
@@ -45,7 +45,7 @@ public class NaverMessageProvider implements OAuthHttpMessageProvider {
         return authorizedClient.getAccessToken().getTokenValue();
     }
 
-    private HttpEntity<MultiValueMap<String, String>> createUnlinkOAuthUserMessage() {
+    private HttpEntity<MultiValueMap<String, String>> createUnlinkUserMessage() {
         HttpHeaders header = createHeader();
         return new HttpEntity<>(header);
     }
@@ -56,7 +56,7 @@ public class NaverMessageProvider implements OAuthHttpMessageProvider {
         return headers;
     }
 
-    private Map<String, String> createUnlinkUriVariables(
+    private Map<String, String> createUnlinkUserUriVariables(
         final ClientRegistration clientRegistration,
         final String accessToken) {
         Map<String, String> urlVariables = new HashMap<>();
@@ -69,7 +69,7 @@ public class NaverMessageProvider implements OAuthHttpMessageProvider {
     }
 
     @Override
-    public void checkSuccessUnlinkRequest(Map<String, Object> unlinkResponse) {
+    public void verifySuccessUnlinkUserRequest(Map<String, Object> unlinkResponse) {
         Optional.ofNullable(unlinkResponse.get(RESULT))
             .filter(result -> result.equals(SUCCESS))
             .orElseThrow(() -> new OAuthUnlinkFailureException("소셜 로그인 연동 해제가 실패하였습니다."));

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/NaverMessageProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/NaverMessageProvider.java
@@ -1,5 +1,8 @@
 package com.prgrms.nabmart.global.auth.oauth.client;
 
+import static com.prgrms.nabmart.global.auth.oauth.constant.OAuthConstant.*;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
 import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import com.prgrms.nabmart.global.auth.exception.OAuthUnlinkFailureException;
 import com.prgrms.nabmart.global.auth.oauth.dto.OAuthHttpMessage;
@@ -7,7 +10,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,7 +21,6 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-@Slf4j
 public class NaverMessageProvider implements OAuthHttpMessageProvider {
 
     private static final String UNLINK_URI = "https://nid.naver.com/oauth2.0/token?"
@@ -28,18 +29,6 @@ public class NaverMessageProvider implements OAuthHttpMessageProvider {
     private static final String REFRESH_ACCESS_TOKEN_URI = "https://nid.naver.com/oauth2.0/token?"
         + "grant_type=refresh_token&client_id={client_id}&"
         + "client_secret={client_secret}&refresh_token={refresh_token}";
-    private static final String CONTENT_TYPE = "Content-Type";
-    private static final String CLIENT_ID = "client_id";
-    private static final String CLIENT_SECRET = "client_secret";
-    private static final String ACCESS_TOKEN = "access_token";
-    private static final String GRANT_TYPE = "grant_type";
-    private static final String SERVICE_PROVIDER = "service_provider";
-    private static final String REFRESH_TOKEN = "refresh_token";
-    private static final String EXPIRES_IN = "expires_in";
-    private static final String DELETE = "delete";
-    private static final String NAVER = "NAVER";
-    private static final String RESULT = "result";
-    private static final String SUCCESS = "success";
 
     @Override
     public OAuthHttpMessage createUserUnlinkRequest(

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/OAuthHttpMessageProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/OAuthHttpMessageProvider.java
@@ -10,11 +10,11 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 
 public interface OAuthHttpMessageProvider {
 
-    OAuthHttpMessage createUserUnlinkRequest(
+    OAuthHttpMessage createUnlinkUserRequest(
         final FindUserDetailResponse userDetailResponse,
         final OAuth2AuthorizedClient authorizedClient);
 
-    void checkSuccessUnlinkRequest(Map<String, Object> unlinkResponse);
+    void verifySuccessUnlinkUserRequest(Map<String, Object> unlinkResponse);
 
     OAuthHttpMessage createRefreshAccessTokenRequest(OAuth2AuthorizedClient authorizedClient);
 

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/OAuthRestClient.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/OAuthRestClient.java
@@ -6,5 +6,5 @@ public interface OAuthRestClient {
 
     void callUnlinkOAuthUser(FindUserDetailResponse userDetailResponse);
 
-    void refreshAccessToken(FindUserDetailResponse userDetailResponse);
+    void callRefreshAccessToken(FindUserDetailResponse userDetailResponse);
 }

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
@@ -36,10 +36,7 @@ public class RestTemplateOAuthClient implements OAuthRestClient {
             userDetailResponse.provider(),
             userDetailResponse.providerId());
 
-        Instant expiresAt = oAuth2AuthorizedClient.getAccessToken().getExpiresAt();
-        if(expiresAt.isBefore(Instant.now())) {
-            refreshAccessToken(userDetailResponse);
-        }
+        refreshAccessTokenIfNotValid(userDetailResponse, oAuth2AuthorizedClient);
 
         OAuthHttpMessage unlinkHttpMessage = oAuthHttpMessageProvider.createUserUnlinkRequest(
             userDetailResponse, oAuth2AuthorizedClient);
@@ -49,6 +46,14 @@ public class RestTemplateOAuthClient implements OAuthRestClient {
         authorizedClientService.removeAuthorizedClient(
             userDetailResponse.provider(),
             userDetailResponse.provider());
+    }
+
+    private void refreshAccessTokenIfNotValid(FindUserDetailResponse userDetailResponse,
+        OAuth2AuthorizedClient oAuth2AuthorizedClient) {
+        Instant expiresAt = oAuth2AuthorizedClient.getAccessToken().getExpiresAt();
+        if(expiresAt.isBefore(Instant.now())) {
+            callRefreshAccessToken(userDetailResponse);
+        }
     }
 
     @Override

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/client/RestTemplateOAuthClient.java
@@ -2,7 +2,7 @@ package com.prgrms.nabmart.global.auth.oauth.client;
 
 import com.prgrms.nabmart.domain.user.service.response.FindUserDetailResponse;
 import com.prgrms.nabmart.global.auth.oauth.dto.OAuthHttpMessage;
-import com.prgrms.nabmart.global.auth.oauth.handler.OAuthProvider;
+import com.prgrms.nabmart.global.auth.oauth.OAuthProvider;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/constant/OAuthConstant.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/constant/OAuthConstant.java
@@ -1,0 +1,26 @@
+package com.prgrms.nabmart.global.auth.oauth.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class OAuthConstant {
+
+    public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_SECRET = "client_secret";
+    public static final String ACCESS_TOKEN = "access_token";
+    public static final String GRANT_TYPE = "grant_type";
+    public static final String SERVICE_PROVIDER = "grant_type";
+    public static final String REFRESH_TOKEN = "refresh_token";
+    public static final String EXPIRES_IN = "expires_in";
+    public static final String DELETE = "delete";
+    public static final String NAVER = "NAVER";
+    public static final String RESULT = "result";
+    public static final String SUCCESS = "success";
+    public static final String TARGET_ID_TYPE = "target_id_type";
+    public static final String USER_ID = "user_id";
+    public static final String TARGET_ID = "target_id";
+    public static final String ID = "id";
+    public static final String APPLICATION_X_WWW_FORM_URLENCODED_CHARSET_UTF_8
+        = "application/x-www-form-urlencoded;charset=utf-8";
+}

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuthProvider.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/handler/OAuthProvider.java
@@ -20,21 +20,8 @@ import java.util.stream.Stream;
 @Getter
 @RequiredArgsConstructor
 public enum OAuthProvider {
-    KAKAO("kakao", attributes -> {
-        Map<String, String> properties = (Map<String, String>) attributes.get("properties");
-        String oAuthUserId = String.valueOf(attributes.get("id"));
-        String nickname = properties.get("nickname");
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        String email = String.valueOf(kakaoAccount.get("email"));
-        return new OAuthUserInfo(oAuthUserId, nickname, email);
-    }, new KakaoMessageProvider()),
-    NAVER("naver", attributes -> {
-        Map<String, String> response = (Map<String, String>) attributes.get("response");
-        String oAuthUserId = response.get("id");
-        String nickname = response.get("nickname");
-        String email = response.get("email");
-        return new OAuthUserInfo(oAuthUserId, nickname, email);
-    }, new NaverMessageProvider());
+    KAKAO("kakao", OAuthProvider::extractKakaoUserInfo, new KakaoMessageProvider()),
+    NAVER("naver", OAuthProvider::extractNaverUserInfo, new NaverMessageProvider());
 
     private static final Map<String, OAuthProvider> PROVIDERS =
         Collections.unmodifiableMap(Stream.of(values())
@@ -43,6 +30,23 @@ public enum OAuthProvider {
     private final String name;
     private final Function<Map<String, Object>, OAuthUserInfo> extractUserInfo;
     private final OAuthHttpMessageProvider oAuthHttpMessageProvider;
+
+    private static OAuthUserInfo extractNaverUserInfo(Map<String, Object> attributes) {
+        Map<String, String> response = (Map<String, String>) attributes.get("response");
+        String oAuthUserId = response.get("id");
+        String nickname = response.get("nickname");
+        String email = response.get("email");
+        return new OAuthUserInfo(oAuthUserId, nickname, email);
+    }
+
+    private static OAuthUserInfo extractKakaoUserInfo(Map<String, Object> attributes) {
+        Map<String, String> properties = (Map<String, String>) attributes.get("properties");
+        String oAuthUserId = String.valueOf(attributes.get("id"));
+        String nickname = properties.get("nickname");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = String.valueOf(kakaoAccount.get("email"));
+        return new OAuthUserInfo(oAuthUserId, nickname, email);
+    }
 
     public static OAuthProvider getOAuthProvider(final String provider) {
         OAuthProvider oAuthProvider = PROVIDERS.get(provider);

--- a/src/main/java/com/prgrms/nabmart/global/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/oauth/service/CustomOAuth2UserService.java
@@ -7,7 +7,7 @@ import com.prgrms.nabmart.domain.user.service.request.RegisterUserCommand;
 import com.prgrms.nabmart.domain.user.service.response.RegisterUserResponse;
 import com.prgrms.nabmart.global.auth.oauth.dto.CustomOAuth2User;
 import com.prgrms.nabmart.global.auth.oauth.dto.OAuthUserInfo;
-import com.prgrms.nabmart.global.auth.oauth.handler.OAuthProvider;
+import com.prgrms.nabmart.global.auth.oauth.OAuthProvider;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/prgrms/nabmart/global/auth/service/RiderAuthenticationService.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/service/RiderAuthenticationService.java
@@ -4,7 +4,7 @@ import com.prgrms.nabmart.domain.delivery.Rider;
 import com.prgrms.nabmart.global.auth.exception.DuplicateUsernameException;
 import com.prgrms.nabmart.domain.delivery.repository.RiderRepository;
 import com.prgrms.nabmart.global.auth.service.request.SignupRiderCommand;
-import com.prgrms.nabmart.global.auth.service.request.RiderLoginCommand;
+import com.prgrms.nabmart.global.auth.service.request.LoginRiderCommand;
 import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.global.auth.exception.InvalidPasswordException;
 import com.prgrms.nabmart.global.auth.exception.InvalidUsernameException;
@@ -48,22 +48,22 @@ public class RiderAuthenticationService {
     }
 
     @Transactional(readOnly = true)
-    public RiderLoginResponse riderLogin(RiderLoginCommand riderLoginCommand) {
-        Rider rider = findRiderByUsername(riderLoginCommand);
-        checkRiderPassword(riderLoginCommand, rider);
+    public RiderLoginResponse loginRider(LoginRiderCommand loginRiderCommand) {
+        Rider rider = findRiderByUsername(loginRiderCommand);
+        verifyRiderPassword(loginRiderCommand, rider);
         CreateTokenCommand createTokenCommand
             = CreateTokenCommand.of(rider.getRiderId(), UserRole.ROLE_RIDER);
         String accessToken = tokenProvider.createToken(createTokenCommand);
         return RiderLoginResponse.from(accessToken);
     }
 
-    private Rider findRiderByUsername(RiderLoginCommand riderLoginCommand) {
-        return riderRepository.findByUsername(riderLoginCommand.username())
+    private Rider findRiderByUsername(LoginRiderCommand loginRiderCommand) {
+        return riderRepository.findByUsername(loginRiderCommand.username())
             .orElseThrow(() -> new InvalidUsernameException("사용자의 정보와 일치하지 않습니다."));
     }
 
-    private void checkRiderPassword(RiderLoginCommand riderLoginCommand, final Rider rider) {
-        if (!passwordEncoder.matches(riderLoginCommand.password(), rider.getPassword())) {
+    private void verifyRiderPassword(LoginRiderCommand loginRiderCommand, final Rider rider) {
+        if (!passwordEncoder.matches(loginRiderCommand.password(), rider.getPassword())) {
             throw new InvalidPasswordException("사용자의 정보와 일치하지 않습니다.");
         }
     }

--- a/src/main/java/com/prgrms/nabmart/global/auth/service/request/LoginRiderCommand.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/service/request/LoginRiderCommand.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.global.auth.service.request;
+
+public record LoginRiderCommand(String username, String password) {
+
+    public static LoginRiderCommand of(final String username, final String password) {
+        return new LoginRiderCommand(username, password);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/auth/service/request/RiderLoginCommand.java
+++ b/src/main/java/com/prgrms/nabmart/global/auth/service/request/RiderLoginCommand.java
@@ -1,8 +1,0 @@
-package com.prgrms.nabmart.global.auth.service.request;
-
-public record RiderLoginCommand(String username, String password) {
-
-    public static RiderLoginCommand of(final String username, final String password) {
-        return new RiderLoginCommand(username, password);
-    }
-}

--- a/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/delivery/service/DeliveryServiceTest.java
@@ -36,7 +36,6 @@ import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
-import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -156,7 +155,7 @@ class DeliveryServiceTest {
             //when
             //then
             assertThatThrownBy(() -> deliveryService.findDelivery(findDeliveryCommand))
-                .isInstanceOf(AuthorizationException.class);
+                .isInstanceOf(UnauthorizedDeliveryException.class);
         }
     }
 

--- a/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/item/service/LikeItemServiceTest.java
@@ -14,6 +14,7 @@ import com.prgrms.nabmart.domain.item.LikeItem;
 import com.prgrms.nabmart.domain.item.exception.DuplicateLikeItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundItemException;
 import com.prgrms.nabmart.domain.item.exception.NotFoundLikeItemException;
+import com.prgrms.nabmart.domain.item.exception.UnauthorizedLikeItemException;
 import com.prgrms.nabmart.domain.item.repository.ItemRepository;
 import com.prgrms.nabmart.domain.item.repository.LikeItemRepository;
 import com.prgrms.nabmart.domain.item.service.request.DeleteLikeItemCommand;
@@ -26,7 +27,6 @@ import com.prgrms.nabmart.domain.user.User;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
 import com.prgrms.nabmart.domain.user.support.UserFixture;
-import com.prgrms.nabmart.global.auth.exception.AuthorizationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -173,7 +173,7 @@ class LikeItemServiceTest {
             //when
             //then
             assertThatThrownBy(() -> likeItemService.deleteLikeItem(notEqualsUserIdCommand))
-                .isInstanceOf(AuthorizationException.class);
+                .isInstanceOf(UnauthorizedLikeItemException.class);
         }
     }
 

--- a/src/test/java/com/prgrms/nabmart/global/auth/controller/RiderAuthenticationControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/controller/RiderAuthenticationControllerTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.prgrms.nabmart.base.BaseControllerTest;
 import com.prgrms.nabmart.global.auth.controller.request.SignupRiderRequest;
-import com.prgrms.nabmart.global.auth.controller.request.RiderLoginRequest;
+import com.prgrms.nabmart.global.auth.controller.request.LoginRiderRequest;
 import com.prgrms.nabmart.global.auth.service.response.RiderLoginResponse;
 import com.prgrms.nabmart.global.auth.support.AuthFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -69,15 +69,15 @@ class RiderAuthenticationControllerTest extends BaseControllerTest {
         @DisplayName("성공")
         void riderLogin() throws Exception {
             //given
-            RiderLoginRequest riderLoginRequest = AuthFixture.riderLoginRequest();
+            LoginRiderRequest loginRiderRequest = AuthFixture.riderLoginRequest();
             RiderLoginResponse riderLoginResponse = new RiderLoginResponse("accessToken");
 
-            given(riderAuthenticationService.riderLogin(any())).willReturn(riderLoginResponse);
+            given(riderAuthenticationService.loginRider(any())).willReturn(riderLoginResponse);
 
             //when
             ResultActions resultActions = mockMvc.perform(post("/api/v1/riders/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(riderLoginRequest))
+                .content(objectMapper.writeValueAsString(loginRiderRequest))
                 .accept(MediaType.APPLICATION_JSON));
 
             //then

--- a/src/test/java/com/prgrms/nabmart/global/auth/controller/request/LoginRiderRequestTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/controller/request/LoginRiderRequestTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class RiderLoginRequestTest {
+class LoginRiderRequestTest {
 
     private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
     private final Validator validator = factory.getValidator();
@@ -33,11 +33,11 @@ class RiderLoginRequestTest {
         @DisplayName("성공")
         void success(String validUsername) {
             //given
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(validUsername, password);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(validUsername, password);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
 
             //then
             assertThat(result).hasSize(0);
@@ -50,11 +50,11 @@ class RiderLoginRequestTest {
         @DisplayName("예외: 유효하지 않은 사용자 이름")
         void throwExceptionWhenInvalidUsername(String invalidUsername) {
             //given
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(invalidUsername, password);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(invalidUsername, password);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
 
             //then
             assertThat(result).hasSize(1);
@@ -67,11 +67,11 @@ class RiderLoginRequestTest {
         void throwExceptionWhenUsernameIsNull() {
             //given
             String nullUsername = null;
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(nullUsername, password);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(nullUsername, password);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
             //then
             assertThat(result).hasSize(1);
             assertThat(result).map(ConstraintViolation::getInvalidValue)
@@ -90,11 +90,11 @@ class RiderLoginRequestTest {
         @DisplayName("성공")
         void success(String validPassword) {
             //given
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(username, validPassword);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(username, validPassword);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
 
             //then
             assertThat(result).hasSize(0);
@@ -107,11 +107,11 @@ class RiderLoginRequestTest {
         @DisplayName("예외: 유효하지 않은 패스워드")
         void throwExceptionWhenInvalidPassword(String invalidPassword) {
             //given
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(username, invalidPassword);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(username, invalidPassword);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
 
             //then
             assertThat(result).hasSize(1);
@@ -124,11 +124,11 @@ class RiderLoginRequestTest {
         void throwExceptionWhenPasswordIsNull() {
             //given
             String nullPassword = null;
-            RiderLoginRequest riderLoginRequest = new RiderLoginRequest(username, nullPassword);
+            LoginRiderRequest loginRiderRequest = new LoginRiderRequest(username, nullPassword);
 
             //when
-            Set<ConstraintViolation<RiderLoginRequest>> result
-                = validator.validate(riderLoginRequest);
+            Set<ConstraintViolation<LoginRiderRequest>> result
+                = validator.validate(loginRiderRequest);
 
             //then
             assertThat(result).hasSize(1);

--- a/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
@@ -21,7 +21,7 @@ class AuthControllerAdviceTest {
     @RestController
     static class AuthExceptionTestController {
 
-        @GetMapping("/auth-ex")
+        @GetMapping("/jwt-ex")
         public void authEx() {
             throw new InvalidJwtException("잘못된 토큰");
         }
@@ -29,6 +29,16 @@ class AuthControllerAdviceTest {
         @GetMapping("/oauth-unlink-ex")
         public void oauthUnlinkEx() {
             throw new OAuthUnlinkFailureException("소셜 로그인 연동 해제 실패");
+        }
+
+        @GetMapping("/un-auth-ex")
+        public void unAuthEx() {
+            throw new UnAuthenticationException("인증되지 않음");
+        }
+
+        @GetMapping("/duplicate-username-ex")
+        public void usernameDuplicateEx() {
+            throw new DuplicateUsernameException("사용자명 중복");
         }
     }
 
@@ -46,15 +56,15 @@ class AuthControllerAdviceTest {
     class AuthExceptionTest {
 
         @Test
-        @DisplayName("성공: authException 잡아서 처리")
-        void throwAuthException() throws Exception {
+        @DisplayName("성공: invalidJwtException 잡아서 처리")
+        void throwInvalidJwtException() throws Exception {
             //given
             //when
-            ResultActions resultActions = mvc.perform(get("/auth-ex"));
+            ResultActions resultActions = mvc.perform(get("/jwt-ex"));
 
             //then
             resultActions.andDo(print())
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").isString());
         }
 
@@ -68,6 +78,19 @@ class AuthControllerAdviceTest {
             //then
             resultActions.andDo(print())
                 .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").isString());
+        }
+
+        @Test
+        @DisplayName("성공: duplicateUsernameException 잡아서 처리")
+        void throwDuplicateUsernameException() throws Exception {
+            //given
+            //when
+            ResultActions resultActions = mvc.perform(get("/duplicate-username-ex"));
+
+            //then
+            resultActions.andDo(print())
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").isString());
         }
     }

--- a/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.prgrms.nabmart.global.auth.controller.AuthControllerAdvice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/exception/AuthControllerAdviceTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-class AuthExceptionHandlerTest {
+class AuthControllerAdviceTest {
 
     @RestController
     static class AuthExceptionTestController {
@@ -36,7 +36,7 @@ class AuthExceptionHandlerTest {
     @BeforeEach
     void setUp() {
         mvc = MockMvcBuilders.standaloneSetup(new AuthExceptionTestController())
-            .setControllerAdvice(new AuthExceptionHandler())
+            .setControllerAdvice(new AuthControllerAdvice())
             .build();
     }
 

--- a/src/test/java/com/prgrms/nabmart/global/auth/service/RiderAuthenticationServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/service/RiderAuthenticationServiceTest.java
@@ -14,7 +14,7 @@ import com.prgrms.nabmart.global.auth.exception.InvalidPasswordException;
 import com.prgrms.nabmart.global.auth.exception.InvalidUsernameException;
 import com.prgrms.nabmart.global.auth.jwt.TokenProvider;
 import com.prgrms.nabmart.global.auth.jwt.dto.Claims;
-import com.prgrms.nabmart.global.auth.service.request.RiderLoginCommand;
+import com.prgrms.nabmart.global.auth.service.request.LoginRiderCommand;
 import com.prgrms.nabmart.global.auth.service.request.SignupRiderCommand;
 import com.prgrms.nabmart.global.auth.service.response.RiderLoginResponse;
 import com.prgrms.nabmart.global.auth.support.AuthFixture;
@@ -86,7 +86,7 @@ class RiderAuthenticationServiceTest {
     @DisplayName("riderLogin 메서드 실행 시")
     class RiderLoginTest {
 
-        RiderLoginCommand riderLoginCommand = AuthFixture.riderLoginCommand();
+        LoginRiderCommand loginRiderCommand = AuthFixture.riderLoginCommand();
         Rider rider = AuthFixture.rider();
 
         @Test
@@ -98,7 +98,7 @@ class RiderAuthenticationServiceTest {
 
             //when
             RiderLoginResponse riderLoginResponse
-                = riderAuthenticationService.riderLogin(riderLoginCommand);
+                = riderAuthenticationService.loginRider(loginRiderCommand);
 
             //then
             Claims claims = tokenProvider.validateToken(riderLoginResponse.accessToken());
@@ -115,7 +115,7 @@ class RiderAuthenticationServiceTest {
 
             //when
             //then
-            assertThatThrownBy(() -> riderAuthenticationService.riderLogin(riderLoginCommand))
+            assertThatThrownBy(() -> riderAuthenticationService.loginRider(loginRiderCommand))
                 .isInstanceOf(InvalidUsernameException.class);
         }
 
@@ -124,14 +124,14 @@ class RiderAuthenticationServiceTest {
         void throwExceptionWhenInvalidPassword() {
             //given
             String invalidPassword = "invalidPassword123";
-            RiderLoginCommand riderLoginCommand
-                = new RiderLoginCommand(rider.getUsername(), invalidPassword);
+            LoginRiderCommand loginRiderCommand
+                = new LoginRiderCommand(rider.getUsername(), invalidPassword);
 
             given(riderRepository.findByUsername(any())).willReturn(Optional.ofNullable(rider));
 
             //when
             //then
-            assertThatThrownBy(() -> riderAuthenticationService.riderLogin(riderLoginCommand))
+            assertThatThrownBy(() -> riderAuthenticationService.loginRider(loginRiderCommand))
                 .isInstanceOf(InvalidPasswordException.class);
         }
     }

--- a/src/test/java/com/prgrms/nabmart/global/auth/support/AuthFixture.java
+++ b/src/test/java/com/prgrms/nabmart/global/auth/support/AuthFixture.java
@@ -1,8 +1,8 @@
 package com.prgrms.nabmart.global.auth.support;
 
 import com.prgrms.nabmart.domain.delivery.Rider;
-import com.prgrms.nabmart.global.auth.controller.request.RiderLoginRequest;
-import com.prgrms.nabmart.global.auth.service.request.RiderLoginCommand;
+import com.prgrms.nabmart.global.auth.controller.request.LoginRiderRequest;
+import com.prgrms.nabmart.global.auth.service.request.LoginRiderCommand;
 import com.prgrms.nabmart.domain.user.UserRole;
 import com.prgrms.nabmart.domain.user.service.response.RegisterUserResponse;
 import com.prgrms.nabmart.global.auth.jwt.JavaJwtTokenProvider;
@@ -53,12 +53,12 @@ public final class AuthFixture {
         return tokenProvider.createToken(createTokenCommand());
     }
 
-    public static RiderLoginCommand riderLoginCommand() {
-        return new RiderLoginCommand(RIDER_USERNAME, RIDER_PASSWORD);
+    public static LoginRiderCommand riderLoginCommand() {
+        return new LoginRiderCommand(RIDER_USERNAME, RIDER_PASSWORD);
     }
 
-    public static RiderLoginRequest riderLoginRequest() {
-        return new RiderLoginRequest(RIDER_USERNAME, RIDER_PASSWORD);
+    public static LoginRiderRequest riderLoginRequest() {
+        return new LoginRiderRequest(RIDER_USERNAME, RIDER_PASSWORD);
     }
 
     public static Rider rider() {


### PR DESCRIPTION
### ⛏ 작업 사항
- `auth` 패키지 하위의 클래스들에 대해 리팩토링을 수행하였습니다.
- 메서드 추출, 클래스/메서드/파라미터/변수명을 개선하였습니다.
- `Delivery`, `LikeItem` 쪽에서 `auth` 패키지 하위의 `AuthorizationException`을 사용하고 있던 것에서 해당 예외를 제거하고 각 도메인별 권한 예외로 분리하였습니다.
- `auth` 패키지 하위의 클래스들 중 일부를 더 적절하다고 판단되는 하위 패키지로 이동시켰습니다.


### 📝 작업 요약
- `AuthorizationException` 제거, `UnauthorizedDeliveryException`, `UnauthorizedLikeItemException` 추가
- `auth` 패키지 하위의 클래스들에 대해 메서드 추출, 이름 변경을 통한 코드 개선


### 💡 관련 이슈
- [NAYB-155](https://naybmart.atlassian.net/browse/NAYB-155)



[NAYB-155]: https://naybmart.atlassian.net/browse/NAYB-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ