### PR TITLE
[NAYB-156] feat: 사용자는 서비스와 연관된 알림을 받아볼 수 있다.

### DIFF
--- a/src/main/java/com/prgrms/nabmart/domain/notification/Notification.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/Notification.java
@@ -1,0 +1,54 @@
+package com.prgrms.nabmart.domain.notification;
+
+import com.prgrms.nabmart.domain.notification.exception.InvalidNotificationException;
+import com.prgrms.nabmart.global.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    private static final int CONTENT_LENGTH = 50;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notificationId;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Builder
+    public Notification(
+        String content,
+        Long userId,
+        NotificationType notificationType) {
+        validateContent(content);
+        this.content = content;
+        this.notificationType = notificationType;
+        this.userId = userId;
+    }
+
+    private void validateContent(String content) {
+        if(Objects.nonNull(content) && content.length() > CONTENT_LENGTH) {
+            throw new InvalidNotificationException("내용의 길이는 50자 이하여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/NotificationController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/NotificationController.java
@@ -1,0 +1,28 @@
+package com.prgrms.nabmart.domain.notification;
+
+import com.prgrms.nabmart.domain.notification.service.NotificationService;
+import com.prgrms.nabmart.global.auth.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/connect", produces = "text/event-stream")
+    public ResponseEntity<SseEmitter> sseConnection(
+        @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
+        @LoginUser Long userId) {
+
+        SseEmitter sseEmitter = notificationService.connection(userId, lastEventId);
+        return ResponseEntity.ok(sseEmitter);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/NotificationType.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/NotificationType.java
@@ -1,0 +1,5 @@
+package com.prgrms.nabmart.domain.notification;
+
+public enum NotificationType {
+    DELIVERY
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/NotificationType.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/NotificationType.java
@@ -1,5 +1,13 @@
 package com.prgrms.nabmart.domain.notification;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum NotificationType {
-    DELIVERY
+    CONNECT("connect"),
+    DELIVERY("delivery");
+
+    private final String value;
 }

--- a/src/main/java/com/prgrms/nabmart/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
-package com.prgrms.nabmart.domain.notification;
+package com.prgrms.nabmart.domain.notification.controller;
 
+import com.prgrms.nabmart.domain.notification.controller.request.ConnectNotificationCommand;
 import com.prgrms.nabmart.domain.notification.service.NotificationService;
 import com.prgrms.nabmart.global.auth.LoginUser;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,9 @@ public class NotificationController {
         @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId,
         @LoginUser Long userId) {
 
-        SseEmitter sseEmitter = notificationService.connection(userId, lastEventId);
+        ConnectNotificationCommand connectNotificationCommand
+            = ConnectNotificationCommand.of(userId, lastEventId);
+        SseEmitter sseEmitter = notificationService.connectNotification(connectNotificationCommand);
         return ResponseEntity.ok(sseEmitter);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/domain/notification/controller/request/ConnectNotificationCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/controller/request/ConnectNotificationCommand.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.notification.controller.request;
+
+public record ConnectNotificationCommand(Long userId, String lastEventId) {
+
+    public static ConnectNotificationCommand of(final Long userId, final String lastEventId) {
+        return new ConnectNotificationCommand(userId, lastEventId);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/exception/InvalidNotificationException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/exception/InvalidNotificationException.java
@@ -1,0 +1,10 @@
+package com.prgrms.nabmart.domain.notification.exception;
+
+import com.prgrms.nabmart.domain.notification.exception.NotificationException;
+
+public class InvalidNotificationException extends NotificationException {
+
+    public InvalidNotificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/exception/NotificationException.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/exception/NotificationException.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.notification.exception;
+
+public abstract class NotificationException extends RuntimeException {
+
+    public NotificationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterMemoryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterMemoryRepository.java
@@ -7,8 +7,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Repository
-public class EmitterMemoryRepository implements
-    EmitterRepository {
+public class EmitterMemoryRepository implements EmitterRepository {
 
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterMemoryRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterMemoryRepository.java
@@ -1,0 +1,32 @@
+package com.prgrms.nabmart.domain.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterMemoryRepository implements
+    EmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllByIdStartWith(Long userId) {
+        String emitterIdPrefix = userId + "_";
+        return emitters.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(emitterIdPrefix))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,13 @@
+package com.prgrms.nabmart.domain.notification.repository;
+
+import java.util.Map;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+
+    void save(String emitterId, SseEmitter sseEmitter);
+
+    void deleteById(String emitterId);
+
+    Map<String, SseEmitter> findAllByIdStartWith(Long userId);
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.nabmart.domain.notification.repository;
+
+import com.prgrms.nabmart.domain.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/service/NotificationService.java
@@ -4,8 +4,10 @@ import static java.text.MessageFormat.format;
 
 import com.prgrms.nabmart.domain.notification.Notification;
 import com.prgrms.nabmart.domain.notification.NotificationType;
+import com.prgrms.nabmart.domain.notification.controller.request.ConnectNotificationCommand;
 import com.prgrms.nabmart.domain.notification.repository.EmitterRepository;
 import com.prgrms.nabmart.domain.notification.repository.NotificationRepository;
+import com.prgrms.nabmart.domain.notification.service.request.SendNotificationCommand;
 import com.prgrms.nabmart.domain.notification.service.response.NotificationResponse;
 import com.prgrms.nabmart.domain.user.exception.NotFoundUserException;
 import com.prgrms.nabmart.domain.user.repository.UserRepository;
@@ -13,9 +15,11 @@ import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
@@ -26,8 +30,11 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
-    public SseEmitter connection(Long userId, String lastEventId) {
-        String emitterId = userId + "_" + System.currentTimeMillis();
+    public SseEmitter connectNotification(ConnectNotificationCommand connectNotificationCommand) {
+        Long userId = connectNotificationCommand.userId();
+        String lastEventId = connectNotificationCommand.lastEventId();
+
+        String emitterId = format("{0}_{1}",userId, System.currentTimeMillis());
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitterRepository.save(emitterId, emitter);
 
@@ -36,33 +43,36 @@ public class NotificationService {
         emitter.onError(e -> emitterRepository.deleteById(emitterId));
 
         // 연결 직후 데이터 전송이 없으면 503 에러 발생. 에러 방지용 더미 데이터 전송
-        sendNotification(emitter, emitterId, format("[Connected] UserId={0}", userId));
+        send(emitter, emitterId, format("[Connected] UserId={0}", userId));
 
         // 클라이언트 미수신한 event를 모두 전송
-        if (!lastEventId.isEmpty()) {
+        if (!connectNotificationCommand.lastEventId().isEmpty()) {
             Map<String, SseEmitter> events = emitterRepository.findAllByIdStartWith(userId);
-            events.entrySet().stream()
-                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
-                .forEach(entry -> sendNotification(emitter, entry.getKey(), entry.getValue()));
+            events.entrySet().stream().filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> send(emitter, entry.getKey(), entry.getValue()));
         }
 
         return emitter;
     }
 
-    private void sendNotification(SseEmitter emitter, String emitterId, Object data) {
+    private void send(SseEmitter emitter, String emitterId, Object data) {
         try {
             emitter.send(SseEmitter.event()
                 .id(emitterId)
                 .data(data));
         } catch (IOException ex) {
             emitterRepository.deleteById(emitterId);
+            log.error("알림 전송에 실패했습니다.", ex);
         }
     }
 
     @Transactional
-    public void send(Long userId, String content, NotificationType notificationType) {
-        verifyExistsUser(userId);
+    public void sendNotification(SendNotificationCommand sendNotificationCommand) {
+        Long userId = sendNotificationCommand.userId();
+        String content = sendNotificationCommand.content();
+        NotificationType notificationType = sendNotificationCommand.notificationType();
 
+        verifyExistsUser(userId);
         Notification notification = Notification.builder()
             .content(content)
             .userId(userId)
@@ -72,7 +82,7 @@ public class NotificationService {
 
         Map<String, SseEmitter> emitters = emitterRepository.findAllByIdStartWith(userId);
         emitters.forEach((key, emitter) -> {
-            sendNotification(emitter, key, NotificationResponse.from(notification));
+            send(emitter, key, NotificationResponse.from(notification));
         });
     }
 
@@ -81,7 +91,7 @@ public class NotificationService {
             .orElseThrow(() -> new NotFoundUserException("존재하지 않는 유저입니다."));
     }
 
-    private void sendNotification(SseEmitter emitter, String emitterId, NotificationResponse data) {
+    private void send(SseEmitter emitter, String emitterId, NotificationResponse data) {
         try {
             emitter.send(SseEmitter.event()
                 .id(emitterId)

--- a/src/main/java/com/prgrms/nabmart/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/service/NotificationService.java
@@ -1,0 +1,52 @@
+package com.prgrms.nabmart.domain.notification.service;
+
+import static java.text.MessageFormat.format;
+
+import com.prgrms.nabmart.domain.notification.repository.EmitterRepository;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 120;
+
+    private final EmitterRepository emitterRepository;
+
+    public SseEmitter connection(Long userId, String lastEventId) {
+        String emitterId = userId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(emitterId, emitter);
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+        emitter.onError(e -> emitterRepository.deleteById(emitterId));
+
+        // 연결 직후 데이터 전송이 없으면 503 에러 발생. 에러 방지용 더미 데이터 전송
+        sendNotification(emitter, emitterId, format("[Connected] UserId={0}", userId));
+
+        // 클라이언트 미수신한 event를 모두 전송
+        if(!lastEventId.isEmpty()) {
+            Map<String, SseEmitter> events = emitterRepository.findAllByIdStartWith(userId);
+            events.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), entry.getValue()));
+        }
+
+        return emitter;
+    }
+
+    private void sendNotification(SseEmitter emitter, String emitterId, Object data) {
+        try {
+            emitter.send(emitter.event()
+                .id(emitterId)
+                .data(data));
+        } catch (IOException ex) {
+            emitterRepository.deleteById(emitterId);
+        }
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/service/request/SendNotificationCommand.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/service/request/SendNotificationCommand.java
@@ -1,0 +1,16 @@
+package com.prgrms.nabmart.domain.notification.service.request;
+
+import com.prgrms.nabmart.domain.notification.NotificationType;
+
+public record SendNotificationCommand(
+    Long userId,
+    String content,
+    NotificationType notificationType) {
+
+    public static SendNotificationCommand of(
+        final Long userId,
+        final String content,
+        final NotificationType notificationType) {
+        return new SendNotificationCommand(userId, content, notificationType);
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/domain/notification/service/response/NotificationResponse.java
+++ b/src/main/java/com/prgrms/nabmart/domain/notification/service/response/NotificationResponse.java
@@ -1,0 +1,22 @@
+package com.prgrms.nabmart.domain.notification.service.response;
+
+import com.prgrms.nabmart.domain.notification.Notification;
+import com.prgrms.nabmart.domain.notification.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+    Long notificationId,
+    String content,
+    NotificationType notificationType,
+    Long userId,
+    LocalDateTime createdAt) {
+
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+            notification.getNotificationId(),
+            notification.getContent(),
+            notification.getNotificationType(),
+            notification.getUserId(),
+            notification.getCreatedAt());
+    }
+}

--- a/src/main/java/com/prgrms/nabmart/global/config/WebMvcConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import com.prgrms.nabmart.global.auth.resolver.LoginUserArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -12,5 +13,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginUserArgumentResolver());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedHeaders("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowCredentials(true);
     }
 }

--- a/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/nabmart/global/config/WebSecurityConfig.java
@@ -65,6 +65,7 @@ public class WebSecurityConfig {
 
     private RequestMatcher[] requestPermitAll() {
         List<RequestMatcher> requestMatchers = List.of(
+            antMatcher(GET, "/api/v1/notifications/**"),
             antMatcher(POST, "/oauth2/authorization/**"),
             antMatcher(POST, "/api/v1/riders/**"),
             antMatcher(GET, "/api/v1/categories/**"),

--- a/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/base/BaseControllerTest.java
@@ -11,6 +11,7 @@ import com.prgrms.nabmart.domain.event.service.EventItemService;
 import com.prgrms.nabmart.domain.event.service.EventService;
 import com.prgrms.nabmart.domain.item.service.ItemService;
 import com.prgrms.nabmart.domain.item.service.LikeItemService;
+import com.prgrms.nabmart.domain.notification.service.NotificationService;
 import com.prgrms.nabmart.domain.order.service.OrderService;
 import com.prgrms.nabmart.domain.payment.service.PaymentClient;
 import com.prgrms.nabmart.domain.payment.service.PaymentService;
@@ -99,6 +100,9 @@ public abstract class BaseControllerTest {
 
     @MockBean
     protected RiderAuthenticationService riderAuthenticationService;
+
+    @MockBean
+    protected NotificationService notificationService;
 
     protected static final String AUTHORIZATION = "Authorization";
 


### PR DESCRIPTION
### ⛏ 작업 사항
- `notification` 도메인을 추가하였습니다.
- 스프링이 제공하는 `SseEmitter` 클래스를 이용하여 Server-Sent Event로 알림을 구현하였습니다.
- `SseEmitter`의 비동기 요청이 완료, 타임아웃, 에러시에 호출되는 메서드가 별도의 스레드에서 호출되기 때문에 concurrentHashMap으로 sseEmitter 객체를 관리하는 메모리 리포지토리를 생성했습니다.
- 배달 쪽 남은 작업을 진행한 후 알림 전송 메서드를 코드에 추가할 예정입니다.
- 프론트에서는 다음과 같은 알림 메시지를 받게 됩니다.
![스크린샷 2023-09-20 오후 9 42 47](https://github.com/prgrms-be-devcourse/BE-04-NaBMart/assets/48748265/87c3fa25-70b1-4b1b-a725-1cec372f8757)


### 📝 작업 요약
- `notification` 패키지 추가
- 사용자에게 전송한 알림 내역을 저장하는 `Notification` 엔티티 추가
- 알림 컨트롤러, 서비스, 리포지토리 메서드 추가


### 💡 관련 이슈
- [NAYB-156](https://naybmart.atlassian.net/browse/NAYB-156)



[NAYB-156]: https://naybmart.atlassian.net/browse/NAYB-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ