### PR TITLE
test: 알림 도메인 테스트 작성 및 문서화 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -406,6 +406,19 @@ include::{snippets}/find-orders/query-parameters.adoc[]
 include::{snippets}/find-orders/http-response.adoc[]
 include::{snippets}/find-orders/response-fields.adoc[]
 
+=== 결제 완료된 주문 목록 조회(직원)
+
+==== Request
+
+include::{snippets}/find-payed-orders/http-request.adoc[]
+include::{snippets}/find-payed-orders/request-headers.adoc[]
+include::{snippets}/find-payed-orders/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/find-payed-orders/http-response.adoc[]
+include::{snippets}/find-payed-orders/response-fields.adoc[]
+
 === 주문 생성
 
 ==== Request
@@ -480,11 +493,39 @@ include::{snippets}/pay-fail/response-fields.adoc[]
 
 == 배달(Delivery)
 
-=== 배달 현황 조회
+=== 배달 생성
+
+==== Request
+
+include::{snippets}/register-delivery/http-request.adoc[]
+include::{snippets}/register-delivery/request-headers.adoc[]
+include::{snippets}/register-delivery/path-parameters.adoc[]
+include::{snippets}/register-delivery/request-fields.adoc[]
+
+
+==== Response
+
+include::{snippets}/register-delivery/http-response.adoc[]
+include::{snippets}/register-delivery/response-headers.adoc[]
+
+=== 배달 현황 조회(유저)
+
+==== Request
+
+include::{snippets}/find-delivery-by-order/http-request.adoc[]
+include::{snippets}/find-delivery-by-order/path-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/find-delivery-by-order/http-response.adoc[]
+include::{snippets}/find-delivery-by-order/response-fields.adoc[]
+
+=== 배달 상세 조회(라이더, 직원)
 
 ==== Request
 
 include::{snippets}/find-delivery/http-request.adoc[]
+include::{snippets}/find-delivery/request-headers.adoc[]
 include::{snippets}/find-delivery/path-parameters.adoc[]
 
 ==== Response
@@ -549,3 +590,16 @@ include::{snippets}/find-rider-deliveries/query-parameters.adoc[]
 
 include::{snippets}/find-rider-deliveries/http-response.adoc[]
 include::{snippets}/find-rider-deliveries/response-fields.adoc[]
+
+== 알림(Notification)
+
+=== 알림 연결
+
+==== Request
+
+include::{snippets}/connect-notification/http-request.adoc[]
+include::{snippets}/connect-notification/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/connect-notification/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -412,7 +412,7 @@ include::{snippets}/find-orders/response-fields.adoc[]
 
 include::{snippets}/find-payed-orders/http-request.adoc[]
 include::{snippets}/find-payed-orders/request-headers.adoc[]
-include::{snippets}/find-payed-orders/request-fields.adoc[]
+include::{snippets}/find-payed-orders/query-parameters.adoc[]
 
 ==== Response
 

--- a/src/test/java/com/prgrms/nabmart/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,45 @@
+package com.prgrms.nabmart.domain.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.prgrms.nabmart.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class NotificationControllerTest extends BaseControllerTest {
+
+    @Nested
+    @DisplayName("sseConnection API 호출 시")
+    class ConnectNotificationTest {
+
+        @Test
+        @DisplayName("성공")
+        void connectNotification() throws Exception {
+            //given
+            SseEmitter emitter = new SseEmitter();
+
+            given(notificationService.connectNotification(any())).willReturn(emitter);
+
+            //when
+            ResultActions resultActions = mockMvc.perform(get("/api/v1/notifications/connect")
+                .header(AUTHORIZATION, accessToken));
+
+            //then
+            resultActions.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                    requestHeaders(
+                        headerWithName(AUTHORIZATION).description("액세스 토큰"),
+                        headerWithName("Last-Event-ID").description("마지막 이벤트 ID").optional()
+                    )
+                ));
+        }
+    }
+}

--- a/src/test/java/com/prgrms/nabmart/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,50 @@
+package com.prgrms.nabmart.domain.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+import com.prgrms.nabmart.domain.notification.controller.request.ConnectNotificationCommand;
+import com.prgrms.nabmart.domain.notification.repository.EmitterRepository;
+import com.prgrms.nabmart.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks
+    NotificationService notificationService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    EmitterRepository emitterRepository;
+
+    @Nested
+    @DisplayName("connectNotification 메서드 실행 시")
+    class ConnectNotificationTest {
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            //given
+            long userId = 1L;
+            ConnectNotificationCommand connectNotificationCommand
+                = ConnectNotificationCommand.of(userId, "");
+
+            //when
+            SseEmitter emitter = notificationService.connectNotification(
+                connectNotificationCommand);
+
+            //then
+            then(emitterRepository).should().save(any(), any());
+        }
+    }
+}


### PR DESCRIPTION
### ⛏ 작업 사항
- 알림 컨트롤러, 서비스 테스트를 작성하였습니다.
- 기존에 추가한 api 중 restDocs 문서 미반영분과 알림 컨트롤러 api 문서화를 추가하였습니다.


### 📝 작업 요약
- NotificationController/Service 테스트 작성
- `결제 완료된 주문 목록 조회(직원)`, `배달 생성`, `배달 상세 조회(라이더, 직원)`,  `알림 연결` api 문서화 추가


### 💡 관련 이슈
- 없음
