### PR TITLE
fix: 쿠폰 기한을 LocalDate 최대값으로 수정

### DIFF
--- a/src/test/java/com/prgrms/nabmart/domain/coupon/CouponTest.java
+++ b/src/test/java/com/prgrms/nabmart/domain/coupon/CouponTest.java
@@ -26,7 +26,7 @@ class CouponTest {
                 .discount(10000)
                 .description("TestDescription")
                 .minOrderPrice(1000)
-                .endAt(LocalDate.parse("2023-12-31"))
+                .endAt(LocalDate.MAX)
                 .build();
 
             // Then

--- a/src/test/java/com/prgrms/nabmart/domain/coupon/support/CouponFixture.java
+++ b/src/test/java/com/prgrms/nabmart/domain/coupon/support/CouponFixture.java
@@ -20,7 +20,7 @@ public class CouponFixture {
     private static final int DISCOUNT = 10000;
     private static final String DESCRIPTION = "쿠폰설명";
     private static final int MIN_ORDER_PRICE = 1000;
-    private static final LocalDate END_AT = LocalDate.parse("2023-12-31");
+    private static final LocalDate END_AT = LocalDate.MAX;
 
     public static Coupon coupon() {
         return Coupon


### PR DESCRIPTION
### ⛏ 작업 사항
- 쿠폰 기한을 LocalDate 최대값으로 수정

### 📝 작업 요약
- 쿠폰 기한이 현재 시간보다 이전으로 설정되어있어서 CI 빌드가 실패하여 최대값으로 수정하였습니다.

### 💡 관련 이슈


